### PR TITLE
HETS-287 - Remove controller CSV model binders for codegen compatibility

### DIFF
--- a/Server/src/HETSAPI/Controllers/EquipmentController.cs
+++ b/Server/src/HETSAPI/Controllers/EquipmentController.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -28,7 +28,7 @@ using HETSAPI.Helpers;
 namespace HETSAPI.Controllers
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public partial class EquipmentController : Controller
     {
@@ -43,7 +43,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Equipment created</response>
@@ -57,7 +57,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         [HttpGet]
@@ -70,7 +70,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular Equipment</remarks>
         /// <param name="id">id of Equipment to fetch attachments for</param>
@@ -86,7 +86,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to delete</param>
         /// <response code="200">OK</response>
@@ -100,7 +100,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch EquipmentAttachments for</param>
         /// <response code="200">OK</response>
@@ -114,7 +114,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch</param>
         /// <response code="200">OK</response>
@@ -129,7 +129,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular Equipment</remarks>
         /// <param name="id">id of Equipment to fetch History for</param>
@@ -146,7 +146,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the Equipment</remarks>
         /// <param name="id">id of Equipment to add History for</param>
@@ -162,7 +162,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch</param>
         /// <param name="item"></param>
@@ -178,7 +178,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch EquipmentViewModel for</param>
         /// <response code="200">OK</response>
@@ -192,7 +192,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Equipment created</response>
@@ -236,7 +236,7 @@ namespace HETSAPI.Controllers
         [Route("/api/equipment/search")]
         [SwaggerOperation("EquipmentSearchGet")]
         [SwaggerResponse(200, type: typeof(List<EquipmentViewModel>))]
-        public virtual IActionResult EquipmentSearchGet([ModelBinder(BinderType = typeof(CsvArrayBinder))]int?[] localareas, [ModelBinder(BinderType = typeof(CsvArrayBinder))]int?[] types, [FromQuery]string equipmentAttachment, [FromQuery]int? owner, [FromQuery]string status, [FromQuery]bool? hired, [FromQuery]DateTime? notverifiedsincedate)
+        public virtual IActionResult EquipmentSearchGet([FromQuery]string localareas, [FromQuery]string types, [FromQuery]string equipmentAttachment, [FromQuery]int? owner, [FromQuery]string status, [FromQuery]bool? hired, [FromQuery]DateTime? notverifiedsincedate)
         {
             return this._service.EquipmentSearchGetAsync(localareas, types, equipmentAttachment, owner, status, hired, notverifiedsincedate);
         }

--- a/Server/src/HETSAPI/Controllers/OwnerController.cs
+++ b/Server/src/HETSAPI/Controllers/OwnerController.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -28,7 +28,7 @@ using HETSAPI.Helpers;
 namespace HETSAPI.Controllers
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public partial class OwnerController : Controller
     {
@@ -43,7 +43,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Owner created</response>
@@ -57,7 +57,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         [HttpGet]
@@ -70,7 +70,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular Owner</remarks>
         /// <param name="id">id of Owner to fetch attachments for</param>
@@ -86,7 +86,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Gets an Owner&#39;s Contacts</remarks>
         /// <param name="id">id of Owner to fetch Contacts for</param>
@@ -101,7 +101,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Adds Owner Contact</remarks>
         /// <param name="id">id of Owner to add a contact for</param>
@@ -117,7 +117,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Owner&#39;s Contacts</remarks>
         /// <param name="id">id of Owner to replace Contacts for</param>
@@ -133,7 +133,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to delete</param>
         /// <response code="200">OK</response>
@@ -147,7 +147,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Gets an Owner&#39;s Equipment</remarks>
         /// <param name="id">id of Owner to fetch Equipment for</param>
@@ -162,7 +162,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Owner&#39;s Equipment</remarks>
         /// <param name="id">id of Owner to replace Equipment for</param>
@@ -178,7 +178,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to fetch</param>
         /// <response code="200">OK</response>
@@ -193,7 +193,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular Owner</remarks>
         /// <param name="id">id of Owner to fetch History for</param>
@@ -210,7 +210,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the Owner</remarks>
         /// <param name="id">id of Owner to add History for</param>
@@ -226,7 +226,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to fetch</param>
         /// <param name="item"></param>
@@ -242,7 +242,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Owner created</response>
@@ -269,7 +269,7 @@ namespace HETSAPI.Controllers
         [Route("/api/owners/search")]
         [SwaggerOperation("OwnersSearchGet")]
         [SwaggerResponse(200, type: typeof(List<Owner>))]
-        public virtual IActionResult OwnersSearchGet([ModelBinder(BinderType = typeof(CsvArrayBinder))]int?[] localareas, [ModelBinder(BinderType = typeof(CsvArrayBinder))]int?[] equipmenttypes, [FromQuery]int? owner, [FromQuery]string status, [FromQuery]bool? hired)
+        public virtual IActionResult OwnersSearchGet([FromQuery]string localareas, [FromQuery]string equipmenttypes, [FromQuery]int? owner, [FromQuery]string status, [FromQuery]bool? hired)
         {
             return this._service.OwnersSearchGetAsync(localareas, equipmenttypes, owner, status, hired);
         }

--- a/Server/src/HETSAPI/Controllers/ProjectController.cs
+++ b/Server/src/HETSAPI/Controllers/ProjectController.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -28,7 +28,7 @@ using HETSAPI.Helpers;
 namespace HETSAPI.Controllers
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public partial class ProjectController : Controller
     {
@@ -43,7 +43,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Project created</response>
@@ -57,7 +57,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         [HttpGet]
@@ -70,7 +70,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular Project</remarks>
         /// <param name="id">id of Project to fetch attachments for</param>
@@ -86,7 +86,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Gets an Project&#39;s Contacts</remarks>
         /// <param name="id">id of Project to fetch Contacts for</param>
@@ -101,7 +101,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Adds Project Contact</remarks>
         /// <param name="id">id of Project to add a contact for</param>
@@ -117,7 +117,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Project&#39;s Contacts</remarks>
         /// <param name="id">id of Project to replace Contacts for</param>
@@ -133,7 +133,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to delete</param>
         /// <response code="200">OK</response>
@@ -147,7 +147,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to fetch</param>
         /// <response code="200">OK</response>
@@ -162,7 +162,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular Project</remarks>
         /// <param name="id">id of Project to fetch History for</param>
@@ -179,7 +179,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the Project</remarks>
         /// <param name="id">id of Project to fetch History for</param>
@@ -195,7 +195,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to fetch</param>
         /// <param name="item"></param>
@@ -211,7 +211,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Project created</response>
@@ -237,7 +237,7 @@ namespace HETSAPI.Controllers
         [Route("/api/projects/search")]
         [SwaggerOperation("ProjectsSearchGet")]
         [SwaggerResponse(200, type: typeof(List<ProjectSearchResultViewModel>))]
-        public virtual IActionResult ProjectsSearchGet([ModelBinder(BinderType = typeof(CsvArrayBinder))]int?[] districts, [FromQuery]string project, [FromQuery]bool? hasRequests, [FromQuery]bool? hasHires)
+        public virtual IActionResult ProjectsSearchGet([FromQuery]string districts, [FromQuery]string project, [FromQuery]bool? hasRequests, [FromQuery]bool? hasHires)
         {
             return this._service.ProjectsSearchGetAsync(districts, project, hasRequests, hasHires);
         }

--- a/Server/src/HETSAPI/Controllers/RentalRequestController.cs
+++ b/Server/src/HETSAPI/Controllers/RentalRequestController.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -28,7 +28,7 @@ using HETSAPI.Helpers;
 namespace HETSAPI.Controllers
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public partial class RentalRequestController : Controller
     {
@@ -43,7 +43,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">RentalRequest created</response>
@@ -57,7 +57,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         [HttpGet]
@@ -70,7 +70,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular RentalRequest</remarks>
         /// <param name="id">id of RentalRequest to fetch attachments for</param>
@@ -86,7 +86,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of RentalRequest to delete</param>
         /// <response code="200">OK</response>
@@ -100,7 +100,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of RentalRequest to fetch</param>
         /// <response code="200">OK</response>
@@ -115,7 +115,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular RentalRequest</remarks>
         /// <param name="id">id of RentalRequest to fetch History for</param>
@@ -132,7 +132,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the RentalRequest</remarks>
         /// <param name="id">id of RentalRequest to add History for</param>
@@ -148,7 +148,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of RentalRequest to fetch</param>
         /// <param name="item"></param>
@@ -164,7 +164,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Updates a rental request rotation list entry.  Side effect is the LocalAreaRotationList is also updated</remarks>
         /// <param name="id">id of RentalRequest to update</param>
@@ -182,7 +182,7 @@ namespace HETSAPI.Controllers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">RentalRequest created</response>
@@ -209,7 +209,7 @@ namespace HETSAPI.Controllers
         [Route("/api/rentalrequests/search")]
         [SwaggerOperation("RentalrequestsSearchGet")]
         [SwaggerResponse(200, type: typeof(List<RentalRequestSearchResultViewModel>))]
-        public virtual IActionResult RentalrequestsSearchGet([ModelBinder(BinderType = typeof(CsvArrayBinder))]int?[] localareas, [FromQuery]string project, [FromQuery]string status, [FromQuery]DateTime? startDate, [FromQuery]DateTime? endDate)
+        public virtual IActionResult RentalrequestsSearchGet([FromQuery]string localareas, [FromQuery]string project, [FromQuery]string status, [FromQuery]DateTime? startDate, [FromQuery]DateTime? endDate)
         {
             return this._service.RentalrequestsSearchGetAsync(localareas, project, status, startDate, endDate);
         }

--- a/Server/src/HETSAPI/Services.Impl/EquipmentService.cs
+++ b/Server/src/HETSAPI/Services.Impl/EquipmentService.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -27,7 +27,7 @@ using Microsoft.AspNetCore.Http;
 namespace HETSAPI.Services.Impl
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class EquipmentService : ServiceBase, IEquipmentService
     {
@@ -72,7 +72,7 @@ namespace HETSAPI.Services.Impl
                 }
 
 
-                // EquipmentAttachments is a list     
+                // EquipmentAttachments is a list
                 if (item.EquipmentAttachments != null)
                 {
                     for (int i = 0; i < item.EquipmentAttachments.Count; i++)
@@ -84,7 +84,7 @@ namespace HETSAPI.Services.Impl
                     }
                 }
 
-                // Attachments is a list     
+                // Attachments is a list
                 if (item.Attachments != null)
                 {
                     for (int i = 0; i < item.Attachments.Count; i++)
@@ -96,7 +96,7 @@ namespace HETSAPI.Services.Impl
                     }
                 }
 
-                // Notes is a list     
+                // Notes is a list
                 if (item.Notes != null)
                 {
                     for (int i = 0; i < item.Notes.Count; i++)
@@ -108,7 +108,7 @@ namespace HETSAPI.Services.Impl
                     }
                 }
 
-                // History is a list     
+                // History is a list
                 if (item.History != null)
                 {
                     for (int i = 0; i < item.History.Count; i++)
@@ -125,7 +125,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Equipment created</response>
@@ -139,7 +139,7 @@ namespace HETSAPI.Services.Impl
             {
                 AdjustRecord(item);
 
-                // determine if this is an insert or an update            
+                // determine if this is an insert or an update
                 bool exists = _context.Equipments.Any(a => a.Id == item.Id);
                 if (exists)
                 {
@@ -156,7 +156,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         public virtual IActionResult EquipmentGetAsync()
@@ -196,7 +196,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular Equipment</remarks>
         /// <param name="id">id of Equipment to fetch attachments for</param>
@@ -222,7 +222,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to delete</param>
         /// <response code="200">OK</response>
@@ -253,7 +253,7 @@ namespace HETSAPI.Services.Impl
                 // Save the changes
 
                 _context.SaveChanges();
-                // update the seniority list 
+                // update the seniority list
                 if (localAreaId != -1 && equipmentTypeId != -1)
                 {
                     _context.CalculateSeniorityList(localAreaId, equipmentTypeId);
@@ -270,7 +270,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular Equipment</remarks>
         /// <param name="id">id of SchoolBus to fetch History for</param>
@@ -312,7 +312,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to Equipment</remarks>
         /// <param name="id">id of SchoolBus to add History for</param>
@@ -350,7 +350,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch EquipmentAttachments for</param>
         /// <response code="200">OK</response>
@@ -372,7 +372,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch</param>
         /// <response code="200">OK</response>
@@ -402,7 +402,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch</param>
         /// <param name="item"></param>
@@ -477,7 +477,7 @@ namespace HETSAPI.Services.Impl
 
             result.LastTimeRecordDateThisYear = null;
 
-            // isWorking is true if there is an active Rental Agreements for the equipment. 
+            // isWorking is true if there is an active Rental Agreements for the equipment.
 
             result.IsWorking = _context.RentalAgreements
                 .Include(x => x.Equipment)
@@ -506,7 +506,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch EquipmentViewModel for</param>
         /// <response code="200">OK</response>
@@ -582,7 +582,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Equipment created</response>
@@ -629,7 +629,7 @@ namespace HETSAPI.Services.Impl
 
 
                 }
-                // return the full object for the client side code.                    
+                // return the full object for the client side code.
 
                 int item_id = item.Id;
                 var result = _context.Equipments
@@ -683,16 +683,19 @@ namespace HETSAPI.Services.Impl
         /// Searches Equipment
         /// </summary>
         /// <remarks>Used for the equipment search page.</remarks>
-        /// <param name="localareas">Local Areas (array of id numbers)</param>
-        /// <param name="types">Equipment Types (array of id numbers)</param>
+        /// <param name="localareasCSV">Local Areas (array of id numbers)</param>
+        /// <param name="typesCSV">Equipment Types (array of id numbers)</param>
         /// <param name="equipmentAttachment">Equipment Attachments </param>
         /// <param name="owner"></param>
         /// <param name="status">Status</param>
         /// <param name="hired">Hired</param>
         /// <param name="notverifiedsincedate">Not Verified Since Date</param>
         /// <response code="200">OK</response>
-        public virtual IActionResult EquipmentSearchGetAsync(int?[] localareas, int?[] types, string equipmentAttachment, int? owner, string status, bool? hired, DateTime? notverifiedsincedate)
+        public virtual IActionResult EquipmentSearchGetAsync(string localareasCSV, string typesCSV, string equipmentAttachment, int? owner, string status, bool? hired, DateTime? notverifiedsincedate)
         {
+            int?[] localareas = ParseIntArray(localareasCSV);
+            int?[] types = ParseIntArray(typesCSV);
+
             var data = _context.Equipments
                     .Include(x => x.LocalArea.ServiceArea.District.Region)
                     .Include(x => x.DistrictEquipmentType)
@@ -756,7 +759,7 @@ namespace HETSAPI.Services.Impl
                 result.Add(newItem);
             }
 
-            // second pass to do calculated fields.            
+            // second pass to do calculated fields.
             foreach (var equipmentViewModel in result)
             {
                 CalculateViewModel(equipmentViewModel);

--- a/Server/src/HETSAPI/Services.Impl/OwnerService.cs
+++ b/Server/src/HETSAPI/Services.Impl/OwnerService.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -27,7 +27,7 @@ using Microsoft.AspNetCore.Http;
 namespace HETSAPI.Services.Impl
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class OwnerService : ServiceBase, IOwnerService
     {
@@ -50,7 +50,7 @@ namespace HETSAPI.Services.Impl
                     item.LocalArea = _context.LocalAreas.FirstOrDefault(a => a.Id == item.LocalArea.Id);
                 }
 
-                // Adjust the owner contacts.            
+                // Adjust the owner contacts.
                 if (item.Contacts != null)
                 {
                     for (int i = 0; i < item.Contacts.Count; i++)
@@ -67,7 +67,7 @@ namespace HETSAPI.Services.Impl
                     item.PrimaryContact = _context.Contacts.FirstOrDefault(a => a.Id == item.PrimaryContact.Id);
                 }
 
-                // Adjust the equipment list.            
+                // Adjust the equipment list.
                 if (item.EquipmentList != null)
                 {
                     for (int i = 0; i < item.EquipmentList.Count; i++)
@@ -91,7 +91,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Owner created</response>
@@ -105,7 +105,7 @@ namespace HETSAPI.Services.Impl
             {
                 AdjustRecord(item);
 
-                // determine if this is an insert or an update            
+                // determine if this is an insert or an update
                 bool exists = _context.Owners.Any(a => a.Id == item.Id);
                 if (exists)
                 {
@@ -122,7 +122,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         public virtual IActionResult OwnersGetAsync()
@@ -134,7 +134,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular Owner</remarks>
         /// <param name="id">id of Owner to fetch attachments for</param>
@@ -160,7 +160,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to fetch Contacts for</param>
         /// <response code="200">OK</response>
@@ -182,7 +182,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Owner&#39;s Contacts</remarks>
         /// <param name="id">id of Owner to replace Contacts for</param>
@@ -222,7 +222,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Owner&#39;s Contacts</remarks>
         /// <param name="id">id of Owner to replace Contacts for</param>
@@ -290,7 +290,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to delete</param>
         /// <response code="200">OK</response>
@@ -318,7 +318,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular Owner</remarks>
         /// <param name="id">id of Owner to fetch History for</param>
@@ -360,7 +360,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the Owner</remarks>
         /// <param name="id">id of Owner to add History for</param>
@@ -398,7 +398,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Gets an Owner&#39;s Equipment</remarks>
         /// <param name="id">id of Owner to fetch Equipment for</param>
@@ -436,7 +436,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Owner&#39;s Equipment</remarks>
         /// <param name="id">id of Owner to replace Equipment for</param>
@@ -529,7 +529,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to fetch</param>
         /// <response code="200">OK</response>
@@ -580,7 +580,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to update</param>
         /// <param name="item"></param>
@@ -616,7 +616,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Owner created</response>
@@ -643,14 +643,17 @@ namespace HETSAPI.Services.Impl
         /// Searches Owners
         /// </summary>
         /// <remarks>Used for the owner search page.</remarks>
-        /// <param name="localareas">Local Areas (array of id numbers)</param>
-        /// <param name="equipmenttypes">Equipment Types (array of id numbers)</param>
+        /// <param name="localAreasCSV">Local Areas (array of id numbers)</param>
+        /// <param name="equipmentTypesCSV">Equipment Types (array of id numbers)</param>
         /// <param name="owner"></param>
         /// <param name="status">Status</param>
         /// <param name="hired">Hired</param>
         /// <response code="200">OK</response>
-        public virtual IActionResult OwnersSearchGetAsync(int?[] localareas, int?[] equipmenttypes, int? owner, string status, bool? hired)
+        public virtual IActionResult OwnersSearchGetAsync(string localAreasCSV, string equipmentTypesCSV, int? owner, string status, bool? hired)
         {
+            int?[] localAreas = ParseIntArray(localAreasCSV);
+            int?[] equipmentTypes = ParseIntArray(equipmentTypesCSV);
+
             var data = _context.Owners
                     .Include(x => x.LocalArea.ServiceArea.District.Region)
                     .Include(x => x.Notes)
@@ -663,9 +666,9 @@ namespace HETSAPI.Services.Impl
             int? districtId = _context.GetDistrictIdByUserId(GetCurrentUserId()).Single();
             data = data.Where(x => x.LocalArea.ServiceArea.DistrictId.Equals(districtId));
 
-            if (localareas != null && localareas.Length > 0)
+            if (localAreas != null && localAreas.Length > 0)
             {
-                data = data.Where(x => localareas.Contains(x.LocalArea.Id));
+                data = data.Where(x => localAreas.Contains(x.LocalArea.Id));
             }
 
             if (status != null)
@@ -695,10 +698,10 @@ namespace HETSAPI.Services.Impl
                 data = data.Where(o => hiredOwnersQuery.Contains(o.Id));
             }
 
-            if (equipmenttypes != null)
+            if (equipmentTypes != null)
             {
                 var equipmentTypeQuery = _context.Equipments
-                    .Where(x => equipmenttypes.Contains(x.DistrictEquipmentTypeId))
+                    .Where(x => equipmentTypes.Contains(x.DistrictEquipmentTypeId))
                     .Select(x => x.OwnerId)
                     .Distinct();
 

--- a/Server/src/HETSAPI/Services.Impl/ProjectService.cs
+++ b/Server/src/HETSAPI/Services.Impl/ProjectService.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -27,12 +27,12 @@ using Microsoft.AspNetCore.Http;
 namespace HETSAPI.Services.Impl
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class ProjectService : ServiceBase, IProjectService
     {
         private readonly DbAppContext _context;
-        
+
         /// <summary>
         /// Create a service and set the database context
         /// </summary>
@@ -51,7 +51,7 @@ namespace HETSAPI.Services.Impl
                     item.District = _context.Districts.FirstOrDefault(a => a.Id == item.District.Id);
                 }
 
-                // Notes is a list     
+                // Notes is a list
                 if (item.Notes != null)
                 {
                     for (int i = 0; i < item.Notes.Count; i++)
@@ -63,7 +63,7 @@ namespace HETSAPI.Services.Impl
                     }
                 }
 
-                // History is a list     
+                // History is a list
                 if (item.History != null)
                 {
                     for (int i = 0; i < item.History.Count; i++)
@@ -102,7 +102,7 @@ namespace HETSAPI.Services.Impl
                     }
                 }
 
-                // RentalAgreements is a list     
+                // RentalAgreements is a list
                 if (item.RentalAgreements != null)
                 {
                     for (int i = 0; i < item.RentalAgreements.Count; i++)
@@ -113,14 +113,14 @@ namespace HETSAPI.Services.Impl
                         }
                     }
                 }
-            }   
+            }
         }
 
 
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Project created</response>
@@ -134,25 +134,25 @@ namespace HETSAPI.Services.Impl
             {
                 AdjustRecord(item);
 
-                // determine if this is an insert or an update            
+                // determine if this is an insert or an update
                 bool exists = _context.Projects.Any(a => a.Id == item.Id);
                 if (exists)
                 {
                     _context.Projects.Update(item);
                 }
                 else
-                {                   
+                {
                     _context.Projects.Add(item);
                 }
                 // Save the changes
                 _context.SaveChanges();
             }
-            
+
             return new NoContentResult();
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         public virtual IActionResult ProjectsGetAsync()
@@ -172,7 +172,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to fetch Contacts for</param>
         /// <response code="200">OK</response>
@@ -200,7 +200,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Owner&#39;s Contacts</remarks>
         /// <param name="id">id of Owner to replace Contacts for</param>
@@ -238,7 +238,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Project&#39;s Contacts</remarks>
         /// <param name="id">id of Project to replace Contacts for</param>
@@ -303,7 +303,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular Project</remarks>
         /// <param name="id">id of Project to fetch attachments for</param>
@@ -330,7 +330,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to delete</param>
         /// <response code="200">OK</response>
@@ -358,7 +358,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular Project</remarks>
         /// <param name="id">id of Project to fetch History for</param>
@@ -400,7 +400,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the Project</remarks>
         /// <param name="id">id of Project to fetch History for</param>
@@ -438,7 +438,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to fetch</param>
         /// <response code="200">OK</response>
@@ -468,7 +468,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to fetch</param>
         /// <param name="item"></param>
@@ -493,7 +493,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Project created</response>
@@ -527,13 +527,15 @@ namespace HETSAPI.Services.Impl
         /// Searches Projects
         /// </summary>
         /// <remarks>Used for the project search page.</remarks>
-        /// <param name="districts">Local areas (array of id numbers)</param>
+        /// <param name="districtsCSV">Local areas (comma seperated list of id numbers)</param>
         /// <param name="project">name or partial name for a Project</param>
         /// <param name="hasRequests">if true then only include Projects with active Requests</param>
         /// <param name="hasHires">if true then only include Projects with active Rental Agreements</param>
         /// <response code="200">OK</response>
-        public virtual IActionResult ProjectsSearchGetAsync(int?[] districts, string project, bool? hasRequests, bool? hasHires)
+        public virtual IActionResult ProjectsSearchGetAsync(string districtsCSV, string project, bool? hasRequests, bool? hasHires)
         {
+            int?[] districts = ParseIntArray(districtsCSV);
+
             var data = _context.Projects
                     .Include(x => x.District.Region)
                     .Include(x => x.PrimaryContact)
@@ -541,7 +543,7 @@ namespace HETSAPI.Services.Impl
 
             if (districts != null && districts.Length > 0)
             {
-                data = data.Where(x => districts.Contains(x.District.Id));                
+                data = data.Where(x => districts.Contains(x.District.Id));
             }
 
             if (hasRequests != null)
@@ -551,7 +553,7 @@ namespace HETSAPI.Services.Impl
 
             if (hasHires != null)
             {
-                // throw new NotImplementedException();          
+                // throw new NotImplementedException();
             }
 
             if (project != null)
@@ -567,7 +569,7 @@ namespace HETSAPI.Services.Impl
                 result.Add(item.ToViewModel());
             }
 
-            // second pass to do calculated fields.            
+            // second pass to do calculated fields.
             foreach (ProjectSearchResultViewModel projectSearchResultViewModel in result)
             {
                 // calculated fields.
@@ -582,7 +584,7 @@ namespace HETSAPI.Services.Impl
                     .Where(x => x.Project.Id == projectSearchResultViewModel.Id)
                     .Count();
             }
-                           
+
             return new ObjectResult(result);
         }
     }

--- a/Server/src/HETSAPI/Services.Impl/RentalRequestService.cs
+++ b/Server/src/HETSAPI/Services.Impl/RentalRequestService.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -27,11 +27,11 @@ using Microsoft.AspNetCore.Http;
 namespace HETSAPI.Services.Impl
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class RentalRequestService : ServiceBase, IRentalRequestService
     {
-        private readonly DbAppContext _context;        
+        private readonly DbAppContext _context;
 
         /// <summary>
         /// Create a service and set the database context
@@ -66,7 +66,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Project created</response>
@@ -95,7 +95,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         public virtual IActionResult RentalrequestsGetAsync()
@@ -113,7 +113,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular RentalRequest</remarks>
         /// <param name="id">id of RentalRequest to fetch attachments for</param>
@@ -140,7 +140,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to delete</param>
         /// <response code="200">OK</response>
@@ -148,7 +148,7 @@ namespace HETSAPI.Services.Impl
         public virtual IActionResult RentalrequestsIdDeletePostAsync(int id)
         {
             var item = _context.RentalRequests
-                .Include (x => x.RentalRequestRotationList)
+                .Include(x => x.RentalRequestRotationList)
                 .FirstOrDefault(a => a.Id == id);
             if (item != null)
             {
@@ -162,9 +162,9 @@ namespace HETSAPI.Services.Impl
                 }
 
                 _context.RentalRequests.Remove(item);
-                    // Save the changes
+                // Save the changes
                 _context.SaveChanges();
-                
+
                 return new ObjectResult(item);
             }
             else
@@ -176,7 +176,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular RentalRequest</remarks>
         /// <param name="id">id of RentalRequest to fetch History for</param>
@@ -218,7 +218,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the Rental Request</remarks>
         /// <param name="id">id of RentalRequest to add History for</param>
@@ -256,7 +256,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to fetch</param>
         /// <response code="200">OK</response>
@@ -285,7 +285,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to fetch</param>
         /// <param name="item"></param>
@@ -310,13 +310,13 @@ namespace HETSAPI.Services.Impl
         }
 
 
-        private void BuildRentalRequestRotationList (RentalRequest item)
+        private void BuildRentalRequestRotationList(RentalRequest item)
         {
             // validate input parameters
             if (item != null && item.LocalArea != null && item.DistrictEquipmentType != null && item.DistrictEquipmentType.EquipmentType != null)
             {
                 int currentSortOrder = 1;
-                
+
                 item.RentalRequestRotationList = new List<RentalRequestRotationList>();
 
                 // first get the localAreaRotationList.askNextBlock1 for the given local area.
@@ -331,14 +331,14 @@ namespace HETSAPI.Services.Impl
 
                 for (int currentBlock = 1; currentBlock <= numberOfBlocks; currentBlock++)
                 {
-                    
+
 
                     int currentBlockSortOrder = 0;
                     // start by getting the current set of equipment for the given equipment type.
 
                     List<Equipment> blockEquipment = _context.Equipments
-                        .Where(x => x.DistrictEquipmentType == item.DistrictEquipmentType && x.BlockNumber == currentBlock  && x.LocalArea.Id == item.LocalArea.Id)
-                        .OrderByDescending(x => x.Seniority)                        
+                        .Where(x => x.DistrictEquipmentType == item.DistrictEquipmentType && x.BlockNumber == currentBlock && x.LocalArea.Id == item.LocalArea.Id)
+                        .OrderByDescending(x => x.Seniority)
                         .ToList();
 
                     int listSize = blockEquipment.Count;
@@ -361,7 +361,7 @@ namespace HETSAPI.Services.Impl
                                 seeking = localAreaRotationList.AskNextBlockOpen;
                                 break;
                         }
-                    }                    
+                    }
 
                     if (localAreaRotationList != null && seeking != null)
                     {
@@ -393,7 +393,7 @@ namespace HETSAPI.Services.Impl
                         }
                     }
                 }
-            }                       
+            }
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace HETSAPI.Services.Impl
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Updates a rental request rotation list entry.  Side effect is the LocalAreaRotationList is also updated</remarks>
         /// <param name="id">id of RentalRequest to update</param>
@@ -452,7 +452,7 @@ namespace HETSAPI.Services.Impl
 
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Project created</response>
@@ -461,7 +461,7 @@ namespace HETSAPI.Services.Impl
             if (item != null)
             {
                 AdjustRecord(item);
-                
+
                 var exists = _context.RentalRequests.Any(a => a.Id == item.Id);
                 if (exists)
                 {
@@ -470,7 +470,7 @@ namespace HETSAPI.Services.Impl
                 else
                 {
                     // record not found
-                    BuildRentalRequestRotationList(item);                                       
+                    BuildRentalRequestRotationList(item);
                     _context.RentalRequests.Add(item);
                 }
                 // Save the changes
@@ -487,18 +487,20 @@ namespace HETSAPI.Services.Impl
         /// Searches Projects
         /// </summary>
         /// <remarks>Used for the project search page.</remarks>
-        /// <param name="localareas">Local areas (array of id numbers)</param>
+        /// <param name="localareasCSV">Local areas (comma seperated list of id numbers)</param>
         /// <param name="project">name or partial name for a Project</param>
         /// <param name="status">Status</param>
         /// <param name="startDate">Inspection start date</param>
         /// <param name="endDate">Inspection end date</param>
         /// <response code="200">OK</response>
-        public virtual IActionResult RentalrequestsSearchGetAsync(int?[] localareas, string project, string status, DateTime? startDate, DateTime? endDate)
-        { 
+        public virtual IActionResult RentalrequestsSearchGetAsync(string localareasCSV, string project, string status, DateTime? startDate, DateTime? endDate)
+        {
+            int?[] localareas = ParseIntArray(localareasCSV);
+
             var data = _context.RentalRequests
                     .Include(x => x.LocalArea.ServiceArea.District.Region)
                     .Include(x => x.DistrictEquipmentType.EquipmentType)
-                    .Include(x => x.Project.PrimaryContact)                    
+                    .Include(x => x.Project.PrimaryContact)
                     .Select(x => x);
 
             // Default search results must be limited to user
@@ -509,7 +511,7 @@ namespace HETSAPI.Services.Impl
             {
                 data = data.Where(x => localareas.Contains(x.LocalArea.Id));
             }
-                        
+
             if (project != null)
             {
                 data = data.Where(x => x.Project.Name.ToLowerInvariant().Contains(project.ToLowerInvariant()));
@@ -541,7 +543,7 @@ namespace HETSAPI.Services.Impl
                 }
             }
 
-            // no calculated fields in a RentalRequest search yet.                           
+            // no calculated fields in a RentalRequest search yet.
             return new ObjectResult(result);
         }
     }

--- a/Server/src/HETSAPI/Services/EquipmentService.cs
+++ b/Server/src/HETSAPI/Services/EquipmentService.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -24,26 +24,26 @@ using HETSAPI.ViewModels;
 namespace HETSAPI.Services
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public interface IEquipmentService
     {
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Equipment created</response>
         IActionResult EquipmentBulkPostAsync(Equipment[] items);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         IActionResult EquipmentGetAsync();
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular Equipment</remarks>
         /// <param name="id">id of Equipment to fetch attachments for</param>
@@ -52,7 +52,7 @@ namespace HETSAPI.Services
         IActionResult EquipmentIdAttachmentsGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to delete</param>
         /// <response code="200">OK</response>
@@ -60,14 +60,14 @@ namespace HETSAPI.Services
         IActionResult EquipmentIdDeletePostAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch EquipmentAttachments for</param>
         /// <response code="200">OK</response>
         IActionResult EquipmentIdEquipmentattachmentsGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch</param>
         /// <response code="200">OK</response>
@@ -75,7 +75,7 @@ namespace HETSAPI.Services
         IActionResult EquipmentIdGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular Equipment</remarks>
         /// <param name="id">id of Equipment to fetch History for</param>
@@ -85,7 +85,7 @@ namespace HETSAPI.Services
         IActionResult EquipmentIdHistoryGetAsync(int id, int? offset, int? limit);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the Equipment</remarks>
         /// <param name="id">id of Equipment to add History for</param>
@@ -94,7 +94,7 @@ namespace HETSAPI.Services
         IActionResult EquipmentIdHistoryPostAsync(int id, History item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch</param>
         /// <param name="item"></param>
@@ -103,14 +103,14 @@ namespace HETSAPI.Services
         IActionResult EquipmentIdPutAsync(int id, Equipment item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Equipment to fetch EquipmentViewModel for</param>
         /// <response code="200">OK</response>
         IActionResult EquipmentIdViewGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Equipment created</response>
@@ -136,6 +136,6 @@ namespace HETSAPI.Services
         /// <param name="hired">Hired</param>
         /// <param name="notverifiedsincedate">Not Verified Since Date</param>
         /// <response code="200">OK</response>
-        IActionResult EquipmentSearchGetAsync(int?[] localareas, int?[] types, string equipmentAttachment, int? owner, string status, bool? hired, DateTime? notverifiedsincedate);
+        IActionResult EquipmentSearchGetAsync(string localareas, string types, string equipmentAttachment, int? owner, string status, bool? hired, DateTime? notverifiedsincedate);
     }
 }

--- a/Server/src/HETSAPI/Services/OwnerService.cs
+++ b/Server/src/HETSAPI/Services/OwnerService.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -24,26 +24,26 @@ using HETSAPI.ViewModels;
 namespace HETSAPI.Services
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public interface IOwnerService
     {
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Owner created</response>
         IActionResult OwnersBulkPostAsync(Owner[] items);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         IActionResult OwnersGetAsync();
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular Owner</remarks>
         /// <param name="id">id of Owner to fetch attachments for</param>
@@ -52,7 +52,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdAttachmentsGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Gets an Owner&#39;s Contacts</remarks>
         /// <param name="id">id of Owner to fetch Contacts for</param>
@@ -60,7 +60,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdContactsGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Adds Owner Contact</remarks>
         /// <param name="id">id of Owner to add a contact for</param>
@@ -69,7 +69,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdContactsPostAsync(int id, Contact item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Owner&#39;s Contacts</remarks>
         /// <param name="id">id of Owner to replace Contacts for</param>
@@ -78,7 +78,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdContactsPutAsync(int id, Contact[] item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to delete</param>
         /// <response code="200">OK</response>
@@ -86,7 +86,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdDeletePostAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Gets an Owner&#39;s Equipment</remarks>
         /// <param name="id">id of Owner to fetch Equipment for</param>
@@ -94,7 +94,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdEquipmentGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Owner&#39;s Equipment</remarks>
         /// <param name="id">id of Owner to replace Equipment for</param>
@@ -103,7 +103,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdEquipmentPutAsync(int id, Equipment[] item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to fetch</param>
         /// <response code="200">OK</response>
@@ -111,7 +111,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular Owner</remarks>
         /// <param name="id">id of Owner to fetch History for</param>
@@ -121,7 +121,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdHistoryGetAsync(int id, int? offset, int? limit);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the Owner</remarks>
         /// <param name="id">id of Owner to add History for</param>
@@ -130,7 +130,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdHistoryPostAsync(int id, History item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Owner to fetch</param>
         /// <param name="item"></param>
@@ -139,7 +139,7 @@ namespace HETSAPI.Services
         IActionResult OwnersIdPutAsync(int id, Owner item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Owner created</response>
@@ -155,6 +155,6 @@ namespace HETSAPI.Services
         /// <param name="status">Status</param>
         /// <param name="hired">Hired</param>
         /// <response code="200">OK</response>
-        IActionResult OwnersSearchGetAsync(int?[] localareas, int?[] equipmenttypes, int? owner, string status, bool? hired);
+        IActionResult OwnersSearchGetAsync(string localareas, string equipmenttypes, int? owner, string status, bool? hired);
     }
 }

--- a/Server/src/HETSAPI/Services/ProjectService.cs
+++ b/Server/src/HETSAPI/Services/ProjectService.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -24,26 +24,26 @@ using HETSAPI.ViewModels;
 namespace HETSAPI.Services
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public interface IProjectService
     {
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">Project created</response>
         IActionResult ProjectsBulkPostAsync(Project[] items);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         IActionResult ProjectsGetAsync();
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular Project</remarks>
         /// <param name="id">id of Project to fetch attachments for</param>
@@ -52,7 +52,7 @@ namespace HETSAPI.Services
         IActionResult ProjectsIdAttachmentsGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Gets an Project&#39;s Contacts</remarks>
         /// <param name="id">id of Project to fetch Contacts for</param>
@@ -60,7 +60,7 @@ namespace HETSAPI.Services
         IActionResult ProjectsIdContactsGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Adds Project Contact</remarks>
         /// <param name="id">id of Project to add a contact for</param>
@@ -69,7 +69,7 @@ namespace HETSAPI.Services
         IActionResult ProjectsIdContactsPostAsync(int id, Contact item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Replaces an Project&#39;s Contacts</remarks>
         /// <param name="id">id of Project to replace Contacts for</param>
@@ -78,7 +78,7 @@ namespace HETSAPI.Services
         IActionResult ProjectsIdContactsPutAsync(int id, Contact[] item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to delete</param>
         /// <response code="200">OK</response>
@@ -86,7 +86,7 @@ namespace HETSAPI.Services
         IActionResult ProjectsIdDeletePostAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to fetch</param>
         /// <response code="200">OK</response>
@@ -94,7 +94,7 @@ namespace HETSAPI.Services
         IActionResult ProjectsIdGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular Project</remarks>
         /// <param name="id">id of Project to fetch History for</param>
@@ -104,7 +104,7 @@ namespace HETSAPI.Services
         IActionResult ProjectsIdHistoryGetAsync(int id, int? offset, int? limit);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the Project</remarks>
         /// <param name="id">id of Project to fetch History for</param>
@@ -113,7 +113,7 @@ namespace HETSAPI.Services
         IActionResult ProjectsIdHistoryPostAsync(int id, History item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of Project to fetch</param>
         /// <param name="item"></param>
@@ -122,7 +122,7 @@ namespace HETSAPI.Services
         IActionResult ProjectsIdPutAsync(int id, Project item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">Project created</response>
@@ -137,6 +137,6 @@ namespace HETSAPI.Services
         /// <param name="hasRequests">if true then only include Projects with active Requests</param>
         /// <param name="hasHires">if true then only include Projects with active Rental Agreements</param>
         /// <response code="200">OK</response>
-        IActionResult ProjectsSearchGetAsync(int?[] districts, string project, bool? hasRequests, bool? hasHires);
+        IActionResult ProjectsSearchGetAsync(string districts, string project, bool? hasRequests, bool? hasHires);
     }
 }

--- a/Server/src/HETSAPI/Services/RentalRequestService.cs
+++ b/Server/src/HETSAPI/Services/RentalRequestService.cs
@@ -1,11 +1,11 @@
 /*
  * REST API Documentation for the MOTI Hired Equipment Tracking System (HETS) Application
  *
- * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists. 
+ * The Hired Equipment Program is for owners/operators who have a dump truck, bulldozer, backhoe or  other piece of equipment they want to hire out to the transportation ministry for day labour and  emergency projects.  The Hired Equipment Program distributes available work to local equipment owners. The program is  based on seniority and is designed to deliver work to registered users fairly and efficiently  through the development of local area call-out lists.
  *
  * OpenAPI spec version: v1
- * 
- * 
+ *
+ *
  */
 
 using System;
@@ -24,26 +24,26 @@ using HETSAPI.ViewModels;
 namespace HETSAPI.Services
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public interface IRentalRequestService
     {
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="items"></param>
         /// <response code="201">RentalRequest created</response>
         IActionResult RentalrequestsBulkPostAsync(RentalRequest[] items);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <response code="200">OK</response>
         IActionResult RentalrequestsGetAsync();
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns attachments for a particular RentalRequest</remarks>
         /// <param name="id">id of RentalRequest to fetch attachments for</param>
@@ -52,7 +52,7 @@ namespace HETSAPI.Services
         IActionResult RentalrequestsIdAttachmentsGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of RentalRequest to delete</param>
         /// <response code="200">OK</response>
@@ -60,7 +60,7 @@ namespace HETSAPI.Services
         IActionResult RentalrequestsIdDeletePostAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of RentalRequest to fetch</param>
         /// <response code="200">OK</response>
@@ -68,7 +68,7 @@ namespace HETSAPI.Services
         IActionResult RentalrequestsIdGetAsync(int id);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Returns History for a particular RentalRequest</remarks>
         /// <param name="id">id of RentalRequest to fetch History for</param>
@@ -78,7 +78,7 @@ namespace HETSAPI.Services
         IActionResult RentalrequestsIdHistoryGetAsync(int id, int? offset, int? limit);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Add a History record to the RentalRequest</remarks>
         /// <param name="id">id of RentalRequest to add History for</param>
@@ -87,7 +87,7 @@ namespace HETSAPI.Services
         IActionResult RentalrequestsIdHistoryPostAsync(int id, History item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id">id of RentalRequest to fetch</param>
         /// <param name="item"></param>
@@ -96,7 +96,7 @@ namespace HETSAPI.Services
         IActionResult RentalrequestsIdPutAsync(int id, RentalRequest item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>Updates a rental request rotation list entry.  Side effect is the LocalAreaRotationList is also updated</remarks>
         /// <param name="id">id of RentalRequest to update</param>
@@ -107,7 +107,7 @@ namespace HETSAPI.Services
         IActionResult RentalrequestsIdRentalrequestrotationlistRentalRequestRotationListIdPutAsync(int id, int rentalRequestRotationListId, RentalRequestRotationList item);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <response code="201">RentalRequest created</response>
@@ -123,6 +123,6 @@ namespace HETSAPI.Services
         /// <param name="startDate">Inspection start date</param>
         /// <param name="endDate">Inspection end date</param>
         /// <response code="200">OK</response>
-        IActionResult RentalrequestsSearchGetAsync(int?[] localareas, string project, string status, DateTime? startDate, DateTime? endDate);
+        IActionResult RentalrequestsSearchGetAsync(string localareas, string project, string status, DateTime? startDate, DateTime? endDate);
     }
 }


### PR DESCRIPTION
Removed CSV model binding from controller and moved responsibility of CSV parsing back to the referenced service methods.