### PR TITLE
HETS-366 - Breakfix - Remove no-unused-vars rule

### DIFF
--- a/Client/.eslintrc.json
+++ b/Client/.eslintrc.json
@@ -53,12 +53,6 @@
             "1tbs", {
                 "allowSingleLine": true
             }
-        ],
-        "no-unused-vars": [
-            "warn", {
-                "vars": "all",
-                "args": "after-used"
-            }
         ]
     }
 }


### PR DESCRIPTION
Rule is preventing front-end from deploying, removed for future review.