### PR TITLE
Update configuration

### DIFF
--- a/Jenkins/server/Jenkinsfile
+++ b/Jenkins/server/Jenkinsfile
@@ -50,7 +50,7 @@ node {
   if( triggerBuild(CONTEXT_DIRECTORY) ) {
     stage('build ' + BUILD_CONFIG) {
       echo "Building: " + BUILD_CONFIG
-      openshiftBuild bldCfg: BUILD_CONFIG, showBuildLogs: 'true'
+      openshiftBuild bldCfg: BUILD_CONFIG, showBuildLogs: 'true', verbose: 'true'
 
       // Don't tag with BUILD_ID so the pruner can do it's job; it won't delete tagged images.
       // Tag the images for deployment based on the image's hash

--- a/openshift/templates/postgresql/postgresql-deploy.json
+++ b/openshift/templates/postgresql/postgresql-deploy.json
@@ -49,7 +49,7 @@
               {
                 "kind": "ImageStreamTag",
                 "namespace": "openshift",
-                "name": "postgresql:9.5"
+                "name": "postgresql:9.4"
               }
             }
           },
@@ -86,7 +86,7 @@
             "containers": [
               {
                 "name": "postgresql",
-                "image": "registry.access.redhat.com/rhscl/postgresql-95-rhel7@sha256:155cf81a3d3a8bbcab3a1f61b177cab75a4105306146d172ef8fb29488cf58b4",
+                "image": "",
                 "ports": [
                   {
                     "containerPort": 5432,

--- a/openshift/templates/schema-spy/schema-spy-deploy.json
+++ b/openshift/templates/schema-spy/schema-spy-deploy.json
@@ -174,7 +174,7 @@
                 "livenessProbe":
                 {
                   "timeoutSeconds": 3000,
-                  "initialDelaySeconds": 30,
+                  "initialDelaySeconds": 300,
                   "httpGet":
                   {
                     "path": "/",


### PR DESCRIPTION
- Turn on verbose logging for the server build.
- Give the schema-spy longer to startup.
- Switch back to postgresql 9.4 in order to retain the database.