### PR TITLE
HETS-434 - Rental Request - Lock list when in use, correct order of hiring

### DIFF
--- a/Server/src/HETSAPI/Controllers/RentalRequestController.cs
+++ b/Server/src/HETSAPI/Controllers/RentalRequestController.cs
@@ -187,7 +187,7 @@ namespace HETSAPI.Controllers
         [Route("/api/rentalrequests/{id}/rentalRequestRotationList")]
         [SwaggerOperation("RentalRequestRotationListIdPut")]
         [SwaggerResponse(200, type: typeof(RentalRequestRotationList))]
-        public virtual IActionResult RentalrequestsIdRentalrequestrotationlistRentalRequestRotationListIdPut([FromRoute]int id, [FromBody]RentalRequestRotationList item)
+        public virtual IActionResult RentalrequestIdRotationListIdPut([FromRoute]int id, [FromBody]RentalRequestRotationList item)
         {
             return _service.RentalrequestRotationListIdPutAsync(id, item);
         }

--- a/Server/src/HETSAPI/ViewModels/RentalRequestViewModel.cs
+++ b/Server/src/HETSAPI/ViewModels/RentalRequestViewModel.cs
@@ -91,8 +91,17 @@ namespace HETSAPI.ViewModels
                     {
                         temp++;
                     }
+
+                    if (equipment.IsForceHire != null &&
+                        equipment.IsForceHire == true)
+                    {
+                        temp++;
+                    }
                 }
             }
+
+            // set the current Yes / Forced Hire Count
+            YesCount = temp;
 
             return temp;
         }       

--- a/Server/src/HETSAPI/appsettings.json
+++ b/Server/src/HETSAPI/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "UpdateLocalDb":  true, 
+  "UpdateLocalDb":  true,
   "Constants": {
     "HangfireUrl": "/hangfire",
     "ErrorUrl": "/error",
@@ -9,7 +9,8 @@
       "HETS-02": "Record has been modified by anther user",
       "HETS-03": "Invalid Region",
       "HETS-04": "Not data provided. Cannot create record",
-      "HETS-05": "Error generating rental agreement pdf document"
+      "HETS-05": "Error generating rental agreement pdf document",
+      "HETS-06": "Rental Request is Complete and cannot be updated"
     }
   },
   "SeniorityScoringRules": {


### PR DESCRIPTION
Ensure Rental Request is Complete when all equipment has been hired
Return the Count of Hired Equipment (including Force Hired)
Ensure the next equipment request is correctly identified