### PR TITLE
HETS-446 - Equipment Seniority - Not displaying "Open" for Lists with only 2 Blocks

### DIFF
--- a/Server/src/HETSAPI/Services.Impl/ProjectService.cs
+++ b/Server/src/HETSAPI/Services.Impl/ProjectService.cs
@@ -385,27 +385,36 @@ namespace HETSAPI.Services.Impl
             if (exists && item != null)
             {
                 Project project = _context.Projects
-                        .Include(x => x.RentalAgreements)
-                        .ThenInclude(t => t.TimeRecords)
+                    .Include(x => x.RentalAgreements)
                     .First(x => x.Id == id);
 
-                // must have the rental agreement id
+                // ******************************************************************
+                // must have the valid rental agreement id
+                // ******************************************************************
                 if (item.RentalAgreement.Id == 0)
                 {
                     // (RENTAL AGREEMENT) record not found
                     return new ObjectResult(new HetsResponse("HETS-01", ErrorViewModel.GetDescription("HETS-01", _configuration)));
                 }
 
-                int rentalAgreementId = item.RentalAgreement.Id;                
+                exists = project.RentalAgreements.Any(a => a.Id == item.RentalAgreement.Id);
 
+                if (!exists)
+                {
+                    // (RENTAL AGREEMENT) record not found
+                    return new ObjectResult(new HetsResponse("HETS-01", ErrorViewModel.GetDescription("HETS-01", _configuration)));
+                }
+
+                // ******************************************************************
                 // add or update time record
+                // ******************************************************************
                 if (item.Id > 0)
                 {
-                    project.RentalAgreements[rentalAgreementId].TimeRecords.Add(item);
+                    _context.TimeRecords.Add(item);
                 }
                 else  // update time record
                 {
-                    project.RentalAgreements[rentalAgreementId].TimeRecords[item.Id] = item;
+                    _context.TimeRecords.Update(item);
                 }
                 
                 _context.SaveChanges();

--- a/Server/src/HETSAPI/Services.Impl/RentalRequestService.cs
+++ b/Server/src/HETSAPI/Services.Impl/RentalRequestService.cs
@@ -592,6 +592,7 @@ namespace HETSAPI.Services.Impl
             if (countOfYeses >= equipmentRequestCount)
             {
                 rentalRequest.Status = "Complete";
+                rentalRequest.FirstOnRotationList = null;
             }                        
 
             // ******************************************************************

--- a/Server/src/HETSAPI/Services.Impl/RentalRequestService.cs
+++ b/Server/src/HETSAPI/Services.Impl/RentalRequestService.cs
@@ -574,6 +574,8 @@ namespace HETSAPI.Services.Impl
             // ******************************************************************
             rentalRequest.RentalRequestRotationList[rotationListIndex] = item;
 
+            // to do: fix the CreateTimestamp and UserId - coming in as nulls
+
             // ******************************************************************
             // can we "Complete" this rental request
             // (if the Yes or Forced Hires = Request.EquipmentCount)

--- a/Server/src/HETSAPI/ViewModels/EquipmentViewModel.cs
+++ b/Server/src/HETSAPI/ViewModels/EquipmentViewModel.cs
@@ -159,7 +159,21 @@ namespace HETSAPI.ViewModels
 
             SenioritySortOrder = temp;
             return temp;
-        }        
+        }
+
+        /// <summary>
+        /// Used to sort the Equipment by Seniority in the UI
+        /// </summary>
+        [DataMember(Name = "senioritySortOrder")]
+        public float SenioritySortOrder { get; set; }
+
+        /// <summary>
+        /// Returns the Number of Blocks for this Piece of Equipment
+        /// </summary>
+        [DataMember(Name = "numberOfBlocks")]
+        public int NumberOfBlocks { get; set; }
+
+        #region Equipment Model Properties
 
         /// <summary>
         /// A system-generated unique identifier for a Equipment
@@ -501,11 +515,7 @@ namespace HETSAPI.ViewModels
         [DataMember(Name="lastTimeRecordDateThisYear")]
         public DateTime? LastTimeRecordDateThisYear { get; set; }
 
-        /// <summary>
-        /// Used to sort the Equipment by Seniority in the UI
-        /// </summary>
-        [DataMember(Name="senioritySortOrder")]
-        public float SenioritySortOrder { get; set; }
+        #endregion        
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -562,6 +572,7 @@ namespace HETSAPI.ViewModels
             sb.Append("  IsWorking: ").Append(IsWorking).Append("\n");
             sb.Append("  LastTimeRecordDateThisYear: ").Append(LastTimeRecordDateThisYear).Append("\n");
             sb.Append("  SenioritySortOrder: ").Append(SenioritySortOrder).Append("\n");
+            sb.Append("  NumberOfBlocks: ").Append(NumberOfBlocks).Append("\n");            
             sb.Append("}\n");
 
             return sb.ToString();

--- a/Server/src/HETSAPI/ViewModels/RentalRequestViewModel.cs
+++ b/Server/src/HETSAPI/ViewModels/RentalRequestViewModel.cs
@@ -106,7 +106,13 @@ namespace HETSAPI.ViewModels
             YesCount = temp;
 
             return temp;
-        }       
+        }
+
+        /// <summary>
+        /// Returns the Number of Blocks for this Rotation List
+        /// </summary>
+        [DataMember(Name = "numberOfBlocks")]
+        public int NumberOfBlocks { get; set; }
 
         #region Standard Rental Request Model Properties
 
@@ -262,6 +268,7 @@ namespace HETSAPI.ViewModels
             sb.Append("  RentalRequestAttachments: ").Append(RentalRequestAttachments).Append("\n");
             sb.Append("  RentalRequestRotationList: ").Append(RentalRequestRotationList).Append("\n");
             sb.Append("  YesCount: ").Append(YesCount).Append("\n");
+            sb.Append("  NumberOfBlocks: ").Append(NumberOfBlocks).Append("\n");
             sb.Append("}\n");
 
             return sb.ToString();


### PR DESCRIPTION
HETS-446 - Equipment Seniority - Not displaying "Open" for Lists with only 2 Blocks
1. Equipment Search - returns Number of Blocks with each equipment record returned (crosses multiple lists)
2. Service Request Rotation List - returns number of Blocks with the Service Request

HETS-436 - Time Entry - save the week and number of hours to db
Fixed error validation (agreement and project not found)
Fixed error saving time record)