### PR TITLE
Update ZAP Jenkinsfile to support authenticated scanning

### DIFF
--- a/Jenkins/zap/Jenkinsfile
+++ b/Jenkins/zap/Jenkinsfile
@@ -1,9 +1,13 @@
-node('zap') {
-    stage('ZAP Security Scan') {
-        dir('/zap') {
-            def retVal = sh returnStatus: true, script: '/zap/zap-baseline.py -r baseline.html -t https://devsm.th.gov.bc.ca/hets/'
-            publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: '/zap/wrk', reportFiles: 'baseline.html', reportName: 'ZAP Baseline Scan', reportTitles: 'ZAP Baseline Scan'])
-            echo "Return value is: ${retVal}"
-        }
+stage('ZAP Security Scan') {
+    node('zap') {
+            //the checkout is mandatory, otherwise functional test would fail
+            echo "checking out source"
+            echo "Build: ${BUILD_ID}"
+            checkout scm
+            dir('zap') {
+                def retVal = sh returnStatus: true, script: '/zap/zap-x.sh -last_scan_report /home/jenkins/workspace/tran-hets-tools-zap-pipeline/zap/index.html -session /home/jenkins/workspace/workspace/tran-hets-tools-zap-pipeline/zap/HETS -cmd'
+                publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: '/home/jenkins/workspace/workspace/tran-hets-tools-zap-pipeline/zap', reportFiles: 'index.html', reportName: 'ZAP Scan', reportTitles: 'ZAP Scan - Build: ${BUILD_ID}'])
+                echo "Return value is: ${retVal}"
+            }
     }
 }


### PR DESCRIPTION
Figured out how to do authenticated scanning (logging into Siteminder).
The ZAP session files will be added shortly once the dev environment is up and running again.