### PR TITLE
Bddstack Node is now dynamically created.

### DIFF
--- a/Jenkins/funtest/Jenkinsfile
+++ b/Jenkins/funtest/Jenkinsfile
@@ -1,33 +1,52 @@
-node('bddstack') {
+podTemplate(label: 'bddstack', name: 'bddstack', serviceAccount: 'jenkins', cloud: 'openshift', containers: [
+  containerTemplate(
+    name: 'jnlp',
+    image: '172.50.0.2:5000/openshift/jenkins-slave-bddstack',
+    resourceRequestCpu: '500m',
+    resourceLimitCpu: '1000m',
+    resourceRequestMemory: '1Gi',
+    resourceLimitMemory: '4Gi',
+    workingDir: '/home/jenkins',
+    command: '',
+    args: '${computer.jnlpmac} ${computer.name}'
+    envVars: [
+        secretEnvVar(key: 'TEST_USERNAME', secretName: 'bddtest-secret', secretKey: 'TEST_USERNAME'),
+        secretEnvVar(key: 'TEST_PASSWORD', secretName: 'bddtest-secret', secretKey: 'TEST_PASSWORD')
+       ]
+  )
+])       
+{
+    node('bddstack') {
 
-	stage('Automated FT') {
-		//the checkout is mandatory, otherwise functional test would fail
-        echo "checking out source"
-        echo "Build: ${BUILD_ID}"
-        checkout scm
-        dir('functional-tests') {
-            try {
-                sh 'export TEST_USERNAME=${TEST_USERNAME}\nexport TEST_PASSWORD=${TEST_PASSWORD}\n./gradlew --debug --stacktrace chromeHeadlessTest'
-                } finally {
-                            archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/geb/**/*'
-                            junit 'build/test-results/**/*.xml'
-                            publishHTML (target: [
-                                        allowMissing: false,
-                                        alwaysLinkToLastBuild: false,
-                                        keepAll: true,
-                                        reportDir: 'build/reports/spock',
-                                        reportFiles: 'index.html',
-                                        reportName: "BDD Spock Report"
-                                    ])
-                            publishHTML (target: [
-                                        allowMissing: false,
-                                        alwaysLinkToLastBuild: false,
-                                        keepAll: true,
-                                        reportDir: 'build/reports/tests/chromeHeadlessTest',
-                                        reportFiles: 'index.html',
-                                        reportName: "Full Test Report"
-                                    ])        
-                    }
+        stage('Automated FT') {
+            //the checkout is mandatory, otherwise functional test would fail
+            echo "checking out source"
+            echo "Build: ${BUILD_ID}"
+            checkout scm
+            dir('functional-tests') {
+                try {
+                    sh 'export TEST_USERNAME=${TEST_USERNAME}\nexport TEST_PASSWORD=${TEST_PASSWORD}\n./gradlew --debug --stacktrace chromeHeadlessTest'
+                    } finally {
+                                archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/geb/**/*'
+                                junit 'build/test-results/**/*.xml'
+                                publishHTML (target: [
+                                            allowMissing: false,
+                                            alwaysLinkToLastBuild: false,
+                                            keepAll: true,
+                                            reportDir: 'build/reports/spock',
+                                            reportFiles: 'index.html',
+                                            reportName: "BDD Spock Report"
+                                        ])
+                                publishHTML (target: [
+                                            allowMissing: false,
+                                            alwaysLinkToLastBuild: false,
+                                            keepAll: true,
+                                            reportDir: 'build/reports/tests/chromeHeadlessTest',
+                                            reportFiles: 'index.html',
+                                            reportName: "Full Test Report"
+                                        ])        
+                        }
+            }
         }
     }
 }


### PR DESCRIPTION
In order to make the full test run run "code-only", we now create the bddstack pod for running our tests dynamically, instead of having to configure this in jenkins.