### PR TITLE
Update chromeDriver version

### DIFF
--- a/functional-tests/build.gradle
+++ b/functional-tests/build.gradle
@@ -15,7 +15,7 @@ ext {
         groovyVersion = '2.4.12'
         gebVersion = '2.0'
         seleniumVersion = '3.6.0'
-        chromeDriverVersion = '2.32'
+        chromeDriverVersion = '2.36'
         geckoDriverVersion = '0.18.0'
         ieDriverVersion = '3.6'
         edgeDriverVersion = seleniumVersion


### PR DESCRIPTION
After multiple reports of issues wit version 2.32, we have now upgraded to 2.36 for the chromeDriver.