### PR TITLE
HETS-625: Add backup script, openshift and Jenkins components to HETS

### DIFF
--- a/Backup/README.md
+++ b/Backup/README.md
@@ -1,0 +1,94 @@
+Postgres Backups in OpenShift
+----------------
+An OpenShift Deployment called "backup" in the HETS projects (Dev, Test, Prod) runs the backups of the Postgres database. The following are the instructions for running the backups and a restore.
+
+Deployment / Configuration
+----------------
+The OpenShift Deployment Template for this application will automatically deploy the Backup app as described below.
+
+The following environment variables are used by the Backup app.
+
+**NOTE**: THESE ENVIRONMENT VARIABLES MUST MATCH THE VARIABLES USED BY THE postgresql DEPLOYMENT DESCRIPTOR.
+
+| Name | Purpose |
+| ---- | ------- |
+| DATABASE_SERVICE_NAME | hostname for the database to backup |
+| POSTGRESQL_USER | database user for the backup |
+| POSTGRESQL_PASSWORD | database password for the backup |
+| POSTGRESQL_DATABASE | database to backup | 
+| BACKUP_DIR | directory to store the backups |
+
+The BACKUP_DIR must be set to a location that has persistent storage.
+
+Backup
+------
+The purpose of the backup app is to do automatic backups.  Deploy the Backup app to do daily backups.  Viewing the Logs for the Backup App will show a record of backups that have been completed.
+
+The Backup app performs the following sequence of operations:
+
+1. Create a directory that will be used to store the backup.
+2. Use the `pg_dump` and `gzip` commands to make a backup.
+3. Cull backups older than 31 days
+4. Sleep for a day and repeat
+
+Note that we are just using a simple "sleep" to run the backup periodically. More elegent solutions were looked at briefly, but there was not a lot of time or benefit, so OpenShift Scheduled Jobs, cron and so on are not used. With some more effort they likely could be made to work.
+
+A separate pod is used vs. having the backups run from the Postgres Pod for fault tolerent purposes - to keep the backups separate from the database storage.  We don't want to, for example, lose the storage of the database, or have the database and backups storage fill up, and lose both the database and the backups.
+
+Immediate Backup:
+-----------------
+To execute a backup right now, check the logs of the Backup pod to make sure a backup isn't run right now (pretty unlikely...), and then deploy the "backup" using OpenShift "deploy" capabilities.
+
+Restore
+-------
+These steps perform a restore of a backup.
+
+1. Log into the OpenShift Console and log into OpenShift on the command shell window.
+   1. The instructions here use a mix of the console and command line, but all could be done from a command shell using "oc" commands. We have not written a script for this as if a backup is needed, something has gone seriously wrong, and compensating steps may be needed for which the script would not account.
+2. Scale to 0 all Apps that use the database connection.
+   1. This is necessary as the Apps will need to restart to pull data from the restored backup.
+   2. In HETS this is just **server**
+   3. It is recommended that you also scale down to 0 **frontend**  so that users know the application is unavailable while the database restore is underway.
+       1. A nice addition to this would be a user-friendly "This application is offline" message - not yet implemented.
+3. Restart the **postgres** pod as a quick way of closing any other database connections from users using port forward or that have rsh'd to directly connect to the database.
+4. Open an rsh into the Postgres pod.
+   1. Open a command prompt connection to OpenShift using `oc login` with parameters appropriate for your OpenShift host.
+   2. Change to the OpenShift project containing the Backup App `oc project <Project Name>`
+   3. List pods using `oc get pods`
+   4. Open a remote shell connection to the **postgresql** pod. `oc rsh <Postgresql Pod Name>`
+5. In the rsh run `psql` 
+6. Get the name of the database and the Application user - you need to know these for later steps.
+   1. Run the shell command: `echo Database Name: $POSTGRESQL_DATABASE`
+   2. Run the shell command: `echo App User: $POSTGRESQL_USER`
+7. Execute `drop <database name>;` to drop the database (database name from above).
+8. Execute `create <database name>;` to create a new instance of the database with the same name as the old one.
+9. Execute `grant all on database hets to "<name of $POSTGRESQL_USER>";`
+    1. If there are other users needing access to the database, such as the DBA group:
+        2. Get a list of the users by running the command `\du`
+        2. For each user that is not "postgres" and $POSTGRESQL_USER, execute the command `GRANT SELECT ON ALL TABLES IN SCHEMA public TO "<name of user>";`
+    2. If users have been set up with other grants, set them up as well.
+10. Close psql with `\q`
+11. Exit rsh with `exit` back to your local command line
+12. Execute `oc rsh <Backup Pod Name>` to remote shell into the backup app pod
+13. Change to the bash shell by entering `bash`
+14. Change to the directory containing the backup you wish to restore and find the name of the file.
+15. Execute the following bash commands:
+    1. `PGPASSWORD=$POSTGRESQL_PASSWORD`
+    2. `export PGPASSWORD`
+    3. `gunzip -c <filename> | psql -h "$DATABASE_SERVICE_NAME" -U "$POSTGRESQL_USER" "$POSTGRESQL_DATABASE" "$POSTGRESQL_DATABASE"`
+       1. Ignore the "no privileges revoked" warnings at the end of the process.
+16. Verify that the database restore worked
+    1. `psql -h "$DATABASE_SERVICE_NAME" -U "$POSTGRESQL_USER" "$POSTGRESQL_DATABASE"`
+    2. `\d`
+    3. Verify that application tables are listed. Query a table - e.g the USER table:
+    4. `SELECT * FROM "SBI_USER";` - you can look at other tables if you want.
+    5. Verify data is shown.
+    6. `\q`
+17. Exit remote shells back to your local commmand line
+18. From the Openshift Console restart the app:
+    1. Scale up (or redeploy) the Server app and wait for it to finish starting up.  View the logs for the Server app to verify there were no startup issues.
+    2. Scale up the CCW app, and view the logs for the CCW app to verify there were no startup issues.
+    3. Scale up the FrontEnd app.
+19.  Verify full application functionality.
+
+Done!

--- a/Backup/backup.Dockerfile
+++ b/Backup/backup.Dockerfile
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/rhscl/postgresql-95-rhel7
+# This image provides a postgres installation from which to run backups 
+
+# Set the workdir to be root
+WORKDIR /
+
+# Load the backup script into the container and make it executable
+COPY backup.sh /
+# RUN chmod -R a+rwx /backup.sh
+
+# Set the default CMD to print the usage of the language image.
+CMD sh /backup.sh
+

--- a/Backup/backup.sh
+++ b/Backup/backup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Postgresql automated backup script
+# See README.md for documentation on this script
+
+FINAL_BACKUP_DIR=$BACKUP_DIR"`date +\%Y-\%m-\%d`/"
+DBFILE=$FINAL_BACKUP_DIR"$POSTGRESQL_DATABASE`date +\%Y-\%m-\%d-%H-%M`"
+echo "Making backup directory in $FINAL_BACKUP_DIR"
+ 
+if ! mkdir -p $FINAL_BACKUP_DIR; then
+	echo "Cannot create backup directory in $FINAL_BACKUP_DIR." 1>&2
+	exit 1;
+fi;
+
+export PGPASSWORD=$POSTGRESQL_PASSWORD
+
+while true; do
+
+	if ! pg_dump -Fp -h "$DATABASE_SERVICE_NAME" -U "$POSTGRESQL_USER" "$POSTGRESQL_DATABASE" | gzip > $DBFILE.sql.gz.in_progress; then
+		echo "[!!ERROR!!] Failed to backup database $POSTGRESQL_DATABASE" 
+	else
+		mv $DBFILE.sql.gz.in_progress $DBFILE.sql.gz
+		echo "Database backup written to $DBFILE.sql.gz"
+		
+		# cull backups older than 31 days.  (SB-331)
+		find $BACKUP_DIR* -type d -ctime +31 | xargs rm -rf
+	fi;
+
+	# 24 hrs
+	sleep 1d
+
+done

--- a/Jenkins/backup/Jenkinsfile
+++ b/Jenkins/backup/Jenkinsfile
@@ -1,0 +1,70 @@
+// Edit your app's name below
+def APP_NAME = 'backup'
+
+// Edit your environment TAG names below
+def TAG_NAMES = ['dev', 'test', 'prod']
+
+// You shouldn't have to edit these if you're following the conventions
+def BUILD_CONFIG = APP_NAME
+def IMAGESTREAM_NAME = APP_NAME
+def PROJECT_NAMESPACE = 'tran-hets-'
+def CONTEXT_DIRECTORY = 'Backup'
+
+@NonCPS
+boolean triggerBuild(String contextDirectory) {
+  // Determine if code has changed within the source context directory.
+  def changeLogSets = currentBuild.changeSets
+  def filesChangeCnt = 0
+  for (int i = 0; i < changeLogSets.size(); i++) {
+    def entries = changeLogSets[i].items
+    for (int j = 0; j < entries.length; j++) {
+      def entry = entries[j]
+      //echo "${entry.commitId} by ${entry.author} on ${new Date(entry.timestamp)}: ${entry.msg}"
+      def files = new ArrayList(entry.affectedFiles)
+      for (int k = 0; k < files.size(); k++) {
+        def file = files[k]
+        def filePath = file.path
+        //echo ">> ${file.path}"
+        if (filePath.contains(contextDirectory)) {
+          filesChangeCnt = 1
+          k = files.size()
+          j = entries.length
+        }
+      }
+    }
+  }
+  
+  if ( filesChangeCnt < 1 ) {
+    echo('The changes do not require a build.')
+    return false
+  }
+  else {
+    echo('The changes require a build.')
+    return true
+  } 
+}
+
+node {
+  if( triggerBuild(CONTEXT_DIRECTORY) ) {
+    stage('build ' + BUILD_CONFIG) {
+      echo "Building: " + BUILD_CONFIG
+      openshiftBuild bldCfg: BUILD_CONFIG, showBuildLogs: 'true'
+
+      // Don't tag with BUILD_ID so the pruner can do it's job; it won't delete tagged images.
+      // Tag the images for deployment based on the image's hash
+      IMAGE_HASH = sh (
+        script: """oc get istag ${IMAGESTREAM_NAME}:latest -o template --template=\"{{.image.dockerImageReference}}\"|awk -F \":\" \'{print \$3}\'""",
+        returnStdout: true).trim()
+      echo ">> IMAGE_HASH: ${IMAGE_HASH}"
+    }
+
+    stage('deploy-' + TAG_NAMES[0]) {
+      openshiftTag destStream: IMAGESTREAM_NAME, destTag: TAG_NAMES[0], srcStream: IMAGESTREAM_NAME, srcTag: "${IMAGE_HASH}"
+    }
+  }
+  else {
+    stage('No Changes') {
+      currentBuild.result = 'SUCCESS'
+    }
+  }
+}

--- a/Jenkins/backup/Jenkinsfile.pipeline.param
+++ b/Jenkins/backup/Jenkinsfile.pipeline.param
@@ -1,0 +1,11 @@
+#=========================================================
+# OpenShift Jenkins pipeline template parameters for:
+# Jenkinsfile: ./Jenkins/backup/Jenkinsfile
+# JSON Template File: https://raw.githubusercontent.com/BCDevOps/openshift-tools/master/provisioning/pipeline/resources/pipeline-build.json
+#=========================================================
+NAME=backup
+# GITHUB_WEBHOOK_SECRET=[a-zA-Z0-9]{40}
+SOURCE_REPOSITORY_URL=https://github.com/bcgov/hets.git
+SOURCE_REPOSITORY_REF=master
+CONTEXT_DIR=Jenkins/backup
+JENKINSFILE_PATH=Jenkinsfile

--- a/openshift/backup-build.param
+++ b/openshift/backup-build.param
@@ -1,0 +1,14 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: .
+# JSON Template File: templates/backup/backup-build.json
+#=========================================================
+NAME=backup
+GIT_REPO_URL=https://github.com/bcgov/hets.git
+GIT_REF=master
+SOURCE_CONTEXT_DIR=/Backup
+SOURCE_IMAGE_KIND=DockerImage
+SOURCE_IMAGE_NAME=registry.access.redhat.com/rhscl/postgresql-95-rhel7
+SOURCE_IMAGE_TAG=latest
+DOCKER_FILE_PATH=backup.Dockerfile
+OUTPUT_IMAGE_TAG=latest

--- a/openshift/backup-deploy.dev.param
+++ b/openshift/backup-deploy.dev.param
@@ -1,0 +1,17 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: .
+# JSON Template File: templates/backup/backup-deploy.json
+#=========================================================
+# NAME=backup
+# SOURCE_IMAGE_NAME=backup
+# APPLICATION_DOMAIN=backup-tran-hets-dev.pathfinder.gov.bc.ca
+# IMAGE_NAMESPACE=tran-hets-tools
+# TAG_NAME=dev
+# DATABASE_SERVICE_NAME=postgresql
+# DATABASE_NAME=hets
+# DATABASE_DEPLOYMENT_NAME=postgresql
+# BACKUP_DIR=/backups/
+# PERSISTENT_VOLUME_NAME=backup-pvc
+# PERSISTENT_VOLUME_SIZE=1Gi
+# MEMORY_LIMIT=512Mi

--- a/openshift/backup-deploy.param
+++ b/openshift/backup-deploy.param
@@ -1,0 +1,17 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: .
+# JSON Template File: templates/backup/backup-deploy.json
+#=========================================================
+NAME=backup
+SOURCE_IMAGE_NAME=backup
+APPLICATION_DOMAIN=backup-tran-hets-dev.pathfinder.gov.bc.ca
+IMAGE_NAMESPACE=tran-hets-tools
+TAG_NAME=dev
+DATABASE_SERVICE_NAME=postgresql
+DATABASE_NAME=hets
+DATABASE_DEPLOYMENT_NAME=postgresql
+BACKUP_DIR=/backups/
+PERSISTENT_VOLUME_NAME=backup-pvc
+PERSISTENT_VOLUME_SIZE=1Gi
+MEMORY_LIMIT=512Mi

--- a/openshift/backup-deploy.prod.param
+++ b/openshift/backup-deploy.prod.param
@@ -1,0 +1,17 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: .
+# JSON Template File: templates/backup/backup-deploy.json
+#=========================================================
+# NAME=backup
+# SOURCE_IMAGE_NAME=backup
+# APPLICATION_DOMAIN=backup-tran-hets-prod.pathfinder.gov.bc.ca
+# IMAGE_NAMESPACE=tran-hets-tools
+# TAG_NAME=prod
+# DATABASE_SERVICE_NAME=postgresql
+# DATABASE_NAME=hets
+# DATABASE_DEPLOYMENT_NAME=postgresql
+# BACKUP_DIR=/backups/
+# PERSISTENT_VOLUME_NAME=backup-pvc
+# PERSISTENT_VOLUME_SIZE=1Gi
+# MEMORY_LIMIT=512Mi

--- a/openshift/backup-deploy.test.param
+++ b/openshift/backup-deploy.test.param
@@ -1,0 +1,17 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: .
+# JSON Template File: templates/backup/backup-deploy.json
+#=========================================================
+# NAME=backup
+# SOURCE_IMAGE_NAME=backup
+# APPLICATION_DOMAIN=backup-tran-hets-test.pathfinder.gov.bc.ca
+# IMAGE_NAMESPACE=tran-hets-tools
+# TAG_NAME=test
+# DATABASE_SERVICE_NAME=postgresql
+# DATABASE_NAME=hets
+# DATABASE_DEPLOYMENT_NAME=postgresql
+# BACKUP_DIR=/backups/
+# PERSISTENT_VOLUME_NAME=backup-pvc
+# PERSISTENT_VOLUME_SIZE=1Gi
+# MEMORY_LIMIT=512Mi

--- a/openshift/templates/backup/backup-build.json
+++ b/openshift/templates/backup/backup-build.json
@@ -1,0 +1,139 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata":
+  {
+    "name": "${NAME}-build-template",
+    "creationTimestamp": null
+  },
+  "objects": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata":
+      {
+        "name": "${NAME}"
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata":
+      {
+        "name": "${NAME}",
+        "labels":
+        {
+          "app": "${NAME}"
+        }
+      },
+      "spec":
+      {
+        "triggers": [
+          {
+            "type": "ImageChange"
+          },
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "runPolicy": "Serial",
+        "source":
+        {
+          "type": "Git",
+          "git":
+          {
+            "uri": "${GIT_REPO_URL}",
+            "ref": "${GIT_REF}"
+          },
+          "contextDir": "${SOURCE_CONTEXT_DIR}"
+        },
+        "strategy":
+        {
+          "type": "Docker",
+          "dockerStrategy":
+          {           
+            "from":
+            {
+              "kind": "${SOURCE_IMAGE_KIND}",
+              "name": "${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}"              
+            },
+            "dockerfilePath": "${DOCKER_FILE_PATH}"            
+          }
+        },
+        "output":
+        {
+          "to":
+          {
+            "kind": "ImageStreamTag",
+            "name": "${NAME}:${OUTPUT_IMAGE_TAG}"
+          }
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAME",
+      "displayName": "Name",
+      "description": "The name assigned to all of the resources defined in this template.",
+      "required": true,
+      "value": "backup"
+    },
+    {
+      "name": "GIT_REPO_URL",
+      "displayName": "Git Repo URL",
+      "description": "The URL to your GIT repo.",
+      "required": true,
+      "value": "https://github.com/bcgov/hets.git"
+    },
+    {
+      "name": "GIT_REF",
+      "displayName": "Git Reference",
+      "description": "The git reference or branch.",
+      "required": true,
+      "value": "master"
+    },
+    {
+      "name": "SOURCE_CONTEXT_DIR",
+      "displayName": "Source Context Directory",
+      "description": "The source context directory.",
+      "required": false,
+      "value": "/Backup"
+    },
+    {
+      "name": "SOURCE_IMAGE_KIND",
+      "displayName": "Source Image Kind",
+      "description": "The 'kind' (type) of the  source image; typically ImageStreamTag, or DockerImage.",
+      "required": true,
+      "value": "DockerImage"
+    },
+    {
+      "name": "SOURCE_IMAGE_NAME",
+      "displayName": "Source Image Name",
+      "description": "The name of the source image.",
+      "required": true,
+      "value": "registry.access.redhat.com/rhscl/postgresql-95-rhel7"
+    },
+    {
+      "name": "SOURCE_IMAGE_TAG",
+      "displayName": "Source Image Tag",
+      "description": "The tag of the source image.",
+      "required": true,
+      "value": "latest"
+    },
+    {
+      "name": "DOCKER_FILE_PATH",
+      "displayName": "Docker File Path",
+      "description": "The path to the docker file defining the build.",
+      "required": false,
+      "value": "backup.Dockerfile"
+    },
+    {
+      "name": "OUTPUT_IMAGE_TAG",
+      "displayName": "Output Image Tag",
+      "description": "The tag given to the built image.",
+      "required": true,
+      "value": "latest"
+    }
+  ]
+}

--- a/openshift/templates/backup/backup-deploy.json
+++ b/openshift/templates/backup/backup-deploy.json
@@ -1,0 +1,248 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata":
+  {
+    "name": "${NAME}-deployment-template"
+  },
+  "objects": [
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata":
+      {
+        "name": "${PERSISTENT_VOLUME_NAME}",
+        "labels":
+        {
+          "app": "${NAME}-persistent",
+          "template": "${NAME}-persistent-template"
+        }
+      },
+      "spec":
+      {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources":
+        {
+          "requests":
+          {
+            "storage": "${PERSISTENT_VOLUME_SIZE}"
+          }
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata":
+      {
+        "name": "${NAME}",
+        "labels":
+        {
+          "template": "${NAME}-deployment"
+        },
+        "annotations":
+        {
+          "description": "Defines how to deploy the ${NAME} server"
+        }
+      },
+      "spec":
+      {
+        "strategy":
+        {
+          "type": "Recreate"
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams":
+            {
+              "automatic": true,
+              "containerNames": [
+                "${NAME}"
+              ],
+              "from":
+              {
+                "kind": "ImageStreamTag",
+                "namespace": "${IMAGE_NAMESPACE}",
+                "name": "${SOURCE_IMAGE_NAME}:${TAG_NAME}"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "selector":
+        {
+          "name": "${NAME}"
+        },
+        "template":
+        {
+          "metadata":
+          {
+            "name": "${NAME}",
+            "labels":
+            {
+              "name": "${NAME}"
+            }
+          },
+          "spec":
+          {
+            "volumes": [
+              {
+                "name": "${NAME}",
+                "persistentVolumeClaim":
+                {
+                  "claimName": "${PERSISTENT_VOLUME_NAME}"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "${NAME}",
+                "image": "",
+                "ports": [],
+                "env": [
+                  {
+                    "name": "BACKUP_DIR",
+                    "value": "${BACKUP_DIR}"
+                  },
+                  {
+                    "name": "DATABASE_SERVICE_NAME",
+                    "value": "${DATABASE_SERVICE_NAME}"
+                  },
+                  {
+                    "name": "POSTGRESQL_DATABASE",
+                    "value": "${DATABASE_NAME}"
+                  },
+                  {
+                    "name": "POSTGRESQL_USER",
+                    "valueFrom":
+                    {
+                      "secretKeyRef":
+                      {
+                        "name": "${DATABASE_DEPLOYMENT_NAME}",
+                        "key": "database-user"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRESQL_PASSWORD",
+                    "valueFrom":
+                    {
+                      "secretKeyRef":
+                      {
+                        "name": "${DATABASE_DEPLOYMENT_NAME}",
+                        "key": "database-password"
+                      }
+                    }
+                  }
+                ],
+                "resources":
+                {
+                  "limits":
+                  {
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "name": "${NAME}",
+                    "mountPath": "${BACKUP_DIR}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAME",
+      "displayName": "Name",
+      "description": "The name assigned to all of the resources defined in this template.",
+      "required": true,
+      "value": "backup"
+    },
+    {
+      "name": "SOURCE_IMAGE_NAME",
+      "displayName": "Source Image Name",
+      "description": "The name of the image to use for this resource.",
+      "required": true,
+      "value": "backup"
+    },
+    {
+      "name": "APPLICATION_DOMAIN",
+      "displayName": "Application Hostname",
+      "description": "The exposed hostname that will route to the application, if left blank a value will be defaulted.",
+      "value": ""
+    },
+    {
+      "name": "IMAGE_NAMESPACE",
+      "displayName": "Image Namespace",
+      "description": "The namespace of the OpenShift project containing the imagestream for the application.",
+      "required": true,
+      "value": "tran-hets-tools"
+    },
+    {
+      "name": "TAG_NAME",
+      "displayName": "Environment TAG name",
+      "description": "The TAG name for this environment, e.g., dev, test, prod",
+      "required": true,
+      "value": "dev"
+    },
+    {
+      "name": "DATABASE_SERVICE_NAME",
+      "displayName": "Database Service Name",
+      "description": "The name of the database service.",
+      "required": true,
+      "value": "postgresql"
+    },
+    {
+      "name": "DATABASE_NAME",
+      "displayName": "Database Name",
+      "description": "The name of the database.",
+      "required": true,
+      "value": "hets"
+    },
+    {
+      "name": "DATABASE_DEPLOYMENT_NAME",
+      "displayName": "Database Deployment Name",
+      "description": "The name associated to the database deployment resources.  In particular, this is used to wrie up the credentials associated to the database.",
+      "required": true,
+      "value": "postgresql"
+    },
+    {
+      "name": "BACKUP_DIR",
+      "displayName": "The root backup directory",
+      "description": "The name of the root backup directory",
+      "required": true,
+      "value": "/backups/"
+    },
+    {
+      "name": "PERSISTENT_VOLUME_NAME",
+      "displayName": "Persistent Volume Name",
+      "description": "The name of the persistent volume associated with the deployment.",
+      "required": true,
+      "value": "backup-pvc"
+    },
+    {
+      "name": "PERSISTENT_VOLUME_SIZE",
+      "displayName": "Persistent Volume Size",
+      "description": "The size of the persistent volume , e.g. 512Mi, 1Gi, 2Gi.",
+      "required": true,
+      "value": "1Gi"
+    },
+    {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "512Mi"
+    }
+  ]
+}


### PR DESCRIPTION
Fully tested locally and looking good.

I recommend that once these are merged @WadeBarnes run the scripts to add these to the Tools and Dev projects so that we can try the script on Dev.

TBD is the size of the PVC needed for backups on Test and Prod.  Current script saves 31 backups - per the request of MOTI for School Bus.  We need to know the size of the Database in those environments and their backup growth rate.