### PR TITLE
HETS-1103 - eslint errors/warnings won't fail webapp build

### DIFF
--- a/Client/.eslintrc.json
+++ b/Client/.eslintrc.json
@@ -33,15 +33,15 @@
             "unix"
         ],
         "quotes": [
-            "error",
+            "warn",
             "single"
         ],
         "semi": [
-            "error",
+            "warn",
             "always"
         ],
         "comma-dangle": [
-            "error",
+            "warn",
             "always-multiline"
         ],
         "no-console": [ "off" ],
@@ -63,6 +63,6 @@
         "no-trailing-spaces": "warn",
         "no-mixed-spaces-and-tabs": "error",
         "no-tabs": "error",
-        "jsx-quotes": ["error", "prefer-double"]
+        "jsx-quotes": ["warn", "prefer-double"]
     }
 }

--- a/Client/src/js/views/BusinessOwner.jsx
+++ b/Client/src/js/views/BusinessOwner.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { connect } from 'react-redux';
 
-import { browserHistory, Link } from 'react-router';
+import { Link } from 'react-router';
 
 import { Well, Row, Col, Alert, Button, Glyphicon, Label } from 'react-bootstrap';
 import _ from 'lodash';

--- a/Client/webpack.config.js
+++ b/Client/webpack.config.js
@@ -21,6 +21,8 @@ var webpackPlugins = [
   }),
 ];
 
+var eslintDevRule = {};
+
 if(IS_PRODUCTION) {
   webpackPlugins.push(new webpack.optimize.UglifyJsPlugin({
     compress: {
@@ -30,7 +32,6 @@ if(IS_PRODUCTION) {
       except: [ '$super', '$', 'exports', 'require' ],
     },
   }));
-  // TODO: See if this is necessary
   webpackPlugins.push(new webpack.DefinePlugin({
     'process.env':{
       'NODE_ENV': JSON.stringify('production'),
@@ -45,6 +46,14 @@ if(IS_PRODUCTION) {
       'DEV_USER': JSON.stringify(DEV_USER),
     },
   }));
+
+  eslintDevRule = {
+    enforce: 'pre',
+    test: /\.jsx?$/,
+    loader: 'eslint-loader',
+    exclude: /node_modules/,
+    options: { emitWarning: true },
+  };
 }
 
 module.exports = {
@@ -77,13 +86,7 @@ module.exports = {
   plugins: webpackPlugins,
   module: {
     rules: [
-      {
-        enforce: 'pre',
-        test: /\.jsx?$/,
-        loader: 'eslint-loader',
-        exclude: /node_modules/,
-        options: { emitWarning: !IS_PRODUCTION, failOnError: IS_PRODUCTION },
-      },
+      eslintDevRule,
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,


### PR DESCRIPTION
When building locally (e.g. `gulp`) ESLint errors show in the app as an overlay w/ the eslint rule violation message. And Eslint warnings will only show up in the browser console.

When building for production (`gulp --produciton`) any ESLint errors or warnings will not fail the build.