### PR TITLE
Revert HETS-1105

### DIFF
--- a/Client/src/js/views/DistrictAdmin.jsx
+++ b/Client/src/js/views/DistrictAdmin.jsx
@@ -2,26 +2,24 @@ import React from 'react';
 
 import { connect } from 'react-redux';
 
-import { PageHeader, Button, ButtonGroup, Glyphicon, Well, Alert, Row, Col, ControlLabel } from 'react-bootstrap';
+import { PageHeader, Button, ButtonGroup, Glyphicon, Well, Alert, Row, Col } from 'react-bootstrap';
 
 import _ from 'lodash';
-
-import ConditionAddEditDialog from './dialogs/ConditionAddEditDialog.jsx';
-import DistrictEquipmentTypeAddEditDialog from './dialogs/DistrictEquipmentTypeAddEditDialog.jsx';
-import EquipmentTransferDialog from './dialogs/EquipmentTransferDialog.jsx';
 
 import * as Api from '../api';
 import * as Constant from '../constants';
 import * as Action from '../actionTypes';
 // import store from '../store';
 
-import Confirm from '../components/Confirm.jsx';
-import DropdownControl from '../components/DropdownControl.jsx';
 import ModalDialog from '../components/ModalDialog.jsx';
-import OverlayTrigger from '../components/OverlayTrigger.jsx';
 import SortTable from '../components/SortTable.jsx';
-import Spinner from '../components/Spinner.jsx';
 import TableControl from '../components/TableControl.jsx';
+import Spinner from '../components/Spinner.jsx';
+import OverlayTrigger from '../components/OverlayTrigger.jsx';
+import Confirm from '../components/Confirm.jsx';
+import ConditionAddEditDialog from './dialogs/ConditionAddEditDialog.jsx';
+import DistrictEquipmentTypeAddEditDialog from './dialogs/DistrictEquipmentTypeAddEditDialog.jsx';
+import EquipmentTransferDialog from './dialogs/EquipmentTransferDialog.jsx';
 
 import SubHeader from '../components/ui/SubHeader.jsx';
 
@@ -33,15 +31,13 @@ var DistrictAdmin = React.createClass({
     rentalConditions: React.PropTypes.object,
     districtEquipmentTypes: React.PropTypes.object,
     equipmentTypes: React.PropTypes.object,
-    uiEquipment: React.PropTypes.object,
-    serviceAreas: React.PropTypes.object,
     router: React.PropTypes.object,
+    uiEquipment: React.PropTypes.object,
     dispatch: React.PropTypes.func,
   },
 
   getInitialState() {
     return {
-      selectedServiceAreaId: 0,
       showConditionAddEditDialog: false,
       showDistrictEquipmentTypeAddEditDialog: false,
       showEquipmentTransferDialog: false,
@@ -60,10 +56,6 @@ var DistrictAdmin = React.createClass({
     Api.getRentalConditions();
     Api.getDistrictEquipmentTypes(this.props.currentUser.district.id);
     Api.getEquipmentTypes();
-  },
-
-  updateState(state, callback) {
-    this.setState(state, callback);
   },
 
   updateEquipmentUIState(state, callback) {
@@ -164,8 +156,6 @@ var DistrictAdmin = React.createClass({
       .sortBy('blueBookSection')
       .value();
 
-    var districtServiceAreas = _.filter(this.props.serviceAreas, area => area.districtId === this.props.currentUser.district.id);
-
     if (!this.props.currentUser.hasPermission(Constant.PERMISSION_DISTRICT_CODE_TABLE_MANAGEMENT) && !this.props.currentUser.hasPermission(Constant.PERMISSION_ADMIN)) {
       return (
         <div>You do not have permission to view this page.</div>
@@ -177,19 +167,12 @@ var DistrictAdmin = React.createClass({
 
       <Well>
         <SubHeader title="Manage District Equipment Types"/>
-        <div id="service-area-filter">
-          <ControlLabel>Service Area:</ControlLabel>
-          <DropdownControl id="selectedServiceAreaId" updateState={ this.updateState } blankLine="(All)" placeholder="(All)" fieldName="id" items={ districtServiceAreas } />
-        </div>
         {(() => {
           if (this.props.districtEquipmentTypes.loading) { return <div style={{ textAlign: 'center' }}><Spinner/></div>; }
 
           var addDistrictEquipmentButton = <Button title="Add District Equipment" bsSize="xsmall" onClick={ this.addDistrictEquipmentType }><Glyphicon glyph="plus" />&nbsp;<strong>Add District Equipment Type</strong></Button>;
 
           var equipmentTypes = this.props.districtEquipmentTypes.data;
-          if (this.state.selectedServiceAreaId) {
-            equipmentTypes = _.filter(this.props.districtEquipmentTypes.data, type => this.state.selectedServiceAreaId === type.serviceAreaId);
-          }
 
           if (Object.keys(equipmentTypes).length === 0) { return <Alert bsStyle="success">No equipment types { addDistrictEquipmentButton }</Alert>; }
 
@@ -297,8 +280,6 @@ var DistrictAdmin = React.createClass({
           onSave={this.onDistrictEquipmentTypeSave}
           districtEquipmentType={this.state.districtEquipmentType}
           equipmentTypes={equipmentTypes}
-          serviceAreas={districtServiceAreas}
-          defaultServiceAreaId={this.state.selectedServiceAreaId}
         />
       }
       { this.state.showDistrictEquipmentTypeErrorDialog &&
@@ -326,7 +307,6 @@ function mapStateToProps(state) {
     rentalConditions: state.lookups.rentalConditions,
     districtEquipmentTypes: state.lookups.districtEquipmentTypes,
     equipmentTypes: state.lookups.equipmentTypes,
-    serviceAreas: state.lookups.serviceAreas,
     uiEquipment: state.ui.districtEquipment,
   };
 }

--- a/Client/src/js/views/dialogs/DistrictEquipmentTypeAddEditDialog.jsx
+++ b/Client/src/js/views/dialogs/DistrictEquipmentTypeAddEditDialog.jsx
@@ -18,8 +18,6 @@ var DistrictEquipmentTypeAddEditDialog = React.createClass({
     show: React.PropTypes.bool,
     districtEquipmentType: React.PropTypes.object,
     equipmentTypes: React.PropTypes.array,
-    serviceAreas: React.PropTypes.array,
-    defaultServiceAreaId: React.PropTypes.number,
   },
 
   getInitialState() {
@@ -29,11 +27,9 @@ var DistrictEquipmentTypeAddEditDialog = React.createClass({
       id: this.props.districtEquipmentType.id || 0,
       equipmentTypeId: this.props.districtEquipmentType.equipmentType ? this.props.districtEquipmentType.equipmentType.id : undefined,
       districtEquipmentName: this.props.districtEquipmentType.districtEquipmentName || '',
-      serviceAreaId: this.props.districtEquipmentType.serviceAreaId || this.props.defaultServiceAreaId || 0,
       concurrencyControlNumber: this.props.districtEquipmentType.concurrencyControlNumber || 0,
       equipmentTypeIdError: '',
       districtEquipmentNameError: '',
-      serviceAreaIdError: '',
     };
   },
 
@@ -44,10 +40,8 @@ var DistrictEquipmentTypeAddEditDialog = React.createClass({
   didChange() {
     if (this.state.isNew && this.state.equipmentTypeId !== undefined) { return true; }
     if (this.state.isNew && this.state.districtEquipmentName !== '') { return true; }
-    if (this.state.isNew && this.state.serviceAreaId !== (this.props.defaultServiceAreaId || 0)) { return true; }
     if (!this.state.isNew && this.state.equipmentTypeId !== this.props.districtEquipmentType.equipmentType.id) { return true; }
     if (!this.state.isNew && this.state.districtEquipmentName !== this.props.districtEquipmentType.districtEquipmentName) { return true; }
-    if (!this.state.isNew && this.state.serviceAreaId !== this.props.districtEquipmentType.serviceAreaId) { return true; }
 
     return false;
   },
@@ -56,7 +50,6 @@ var DistrictEquipmentTypeAddEditDialog = React.createClass({
     this.setState({
       equipmentTypeIdError: '',
       districtEquipmentNameError: '',
-      serviceAreaIdError: '',
     });
 
     var valid = true;
@@ -77,11 +70,6 @@ var DistrictEquipmentTypeAddEditDialog = React.createClass({
       valid = false;
     }
 
-    if (!this.state.serviceAreaId) {
-      this.setState({ serviceAreaIdError: 'Service area is required' });
-      valid = false;
-    }
-
     return valid;
   },
 
@@ -90,7 +78,6 @@ var DistrictEquipmentTypeAddEditDialog = React.createClass({
       id: this.state.id,
       equipmentType: { id: this.state.equipmentTypeId },
       districtEquipmentName: this.state.districtEquipmentName,
-      serviceAreaId: this.state.serviceAreaId,
       concurrencyControlNumber: this.state.concurrencyControlNumber,
     });
   },
@@ -112,14 +99,6 @@ var DistrictEquipmentTypeAddEditDialog = React.createClass({
           <ControlLabel>Equipment Type/Description <sup>*</sup></ControlLabel>
           <FormInputControl type="text" value={ this.state.districtEquipmentName } updateState={ this.updateState }/>
           <HelpBlock>{ this.state.districtEquipmentNameError }</HelpBlock>
-        </FormGroup>
-        <FormGroup controlId="serviceAreaId" validationState={ this.state.serviceAreaIdError ? 'error' : null }>
-          <ControlLabel>Service Area <sup>*</sup></ControlLabel>
-          <FilterDropdown id="serviceAreaId" fieldName="id" selectedId={ this.state.serviceAreaId } updateState={ this.updateState }
-            items={ this.props.serviceAreas }
-            className="full-width"
-          />
-          <HelpBlock>{ this.state.serviceAreaIdError }</HelpBlock>
         </FormGroup>
       </Form>
     </EditDialog>;

--- a/Client/src/sass/views/district-admin.scss
+++ b/Client/src/sass/views/district-admin.scss
@@ -1,8 +1,2 @@
 #district-admin {
-  #service-area-filter {
-    .control-label {
-      margin: 5px;
-      font-weight: normal;
-    }
-  }
 }

--- a/Server/src/HetsApi/Controllers/DistrictEquipmentTypeController.cs
+++ b/Server/src/HetsApi/Controllers/DistrictEquipmentTypeController.cs
@@ -208,7 +208,6 @@ namespace HetsApi.Controllers
                 equipment.ConcurrencyControlNumber = item.ConcurrencyControlNumber;
                 equipment.DistrictId = item.District.DistrictId;
                 equipment.EquipmentTypeId = item.EquipmentType.EquipmentTypeId;
-                equipment.ServiceAreaId = item.ServiceAreaId;
             }
             else
             {
@@ -216,8 +215,7 @@ namespace HetsApi.Controllers
                 {
                     DistrictEquipmentName = item.DistrictEquipmentName,
                     DistrictId = item.District.DistrictId,
-                    EquipmentTypeId = item.EquipmentType.EquipmentTypeId,
-                    ServiceAreaId = item.ServiceAreaId
+                    EquipmentTypeId = item.EquipmentType.EquipmentTypeId
                 };
 
                 _context.HetDistrictEquipmentType.Add(equipment);


### PR DESCRIPTION
We've agreed on an alternative solution for tackling district equipment types in different service areas, so HETS-1105 is no longer needed.

Revert "HETS-1105 filter equipment types on service area on district admin page"

This reverts commit 7b9f44d99d232279844e8151ffc3b76de040dd83.

Revert "HETS-1105 add service area dropdown to equipment type dialog"

This reverts commit 280fb0d05401d9e458e9107795278660cfe2ff45.