### PR TITLE
Revert frontend changes for HETS-1088

### DIFF
--- a/Client/src/js/views/DistrictAdmin.jsx
+++ b/Client/src/js/views/DistrictAdmin.jsx
@@ -174,7 +174,6 @@ var DistrictAdmin = React.createClass({
 
           var headers = [
             { field: 'districtEquipmentName',         title: 'Equipment Type/Description'  },
-            { field: 'serviceAreaId',                 title: 'Service Area'  },
             { field: 'equipmentType.blueBookSection', title: 'Blue Book Section Number'  },
             { field: 'equipmentType.name',            title: 'Blue Book Section Name'  },
             { field: 'addDistrictEquipmentType',      title: 'Add District Equipment Type',  style: { textAlign: 'right'  },
@@ -188,7 +187,6 @@ var DistrictAdmin = React.createClass({
                 _.map(sortedEquipmentTypes, (equipment) => {
                   return <tr key={ equipment.id }>
                     <td>{ equipment.districtEquipmentName }</td>
-                    <td>{ equipment.serviceAreaId }</td>
                     <td>{ equipment.equipmentType.blueBookSection }</td>
                     <td>{ equipment.equipmentType.name }</td>
                     <td style={{ textAlign: 'right' }}>


### PR DESCRIPTION
We've agreed on an alternative solution for tackling district equipment types in different service areas, so the original changes described in HETS-1088 are no longer needed.  This commit removes the service area column from the District Equipment Type list on the District Admin page.

Partially revert "HETS-1088 - Add service Area to the District Equipment Type"

This partially reverts commit 4df1074.