### PR TITLE
HETS-1160 - fixes always disabled 'Asked' radio in Hire dialog

### DIFF
--- a/Client/src/js/views/dialogs/HireOfferEditDialog.jsx
+++ b/Client/src/js/views/dialogs/HireOfferEditDialog.jsx
@@ -325,7 +325,7 @@ var HireOfferEditDialog = React.createClass({
                       <Radio
                         onChange={ this.offerStatusChanged.bind(this, STATUS_ASKED) }
                         checked={ this.state.offerStatus == STATUS_ASKED }
-                        disabled={ !this.props.hireOffer.showAllResponseFields && !this.props.hireOffer.offerResponse }
+                        disabled={ !this.props.showAllResponseFields && !this.props.hireOffer.offerResponse }
                       >
                         Asked
                       </Radio>


### PR DESCRIPTION
#1510 introduced a bug where the “Asked” radio option was always disabled while fixing a different bug w.r.t. store mutations.