### PR TITLE
HETS-1206 fix missing local area for agreements on project page

### DIFF
--- a/Common/src/HetsData/Helpers/ProjectHelper.cs
+++ b/Common/src/HetsData/Helpers/ProjectHelper.cs
@@ -137,8 +137,12 @@ namespace HetsData.Helpers
                     if (rentalAgreement.Equipment.LocalArea != null)
                     {
                         rentalAgreement.LocalAreaName = rentalAgreement.Equipment.LocalArea.Name;
-                        rentalAgreement.Equipment.LocalArea = null;
                     }
+                }
+
+                foreach (HetRentalAgreement rentalAgreement in project.HetRentalAgreement)
+                {
+                    rentalAgreement.Equipment.LocalArea = null;
                 }
 
                 foreach (HetRentalRequest rentalRequest in project.HetRentalRequest)


### PR DESCRIPTION
If a project has multiple agreements that share the same equipment, we don't want to null out the equipment's LocalArea until all agreements have had their LocalAreaName assigned.