### PR TITLE
HETS-1219 include page count and date when printing

### DIFF
--- a/Client/src/sass/print.scss
+++ b/Client/src/sass/print.scss
@@ -1,5 +1,5 @@
 @page {
-  margin: 5mm;
+  margin: 10mm 5mm;
 }
 
 @media print {


### PR DESCRIPTION
We previously specified a top and bottom margin of 5mm to hide the built-in information that Chrome adds when printing: the date, the page title, the URL, the current page number, and the page count.  By increasing the margin to 10mm, that information will again be included.