### PR TITLE
1.9.3 HETS-1328 part 2 and minor UI fix

### DIFF
--- a/Server/HetsData/Repositories/RentalRequestRepository.cs
+++ b/Server/HetsData/Repositories/RentalRequestRepository.cs
@@ -87,6 +87,7 @@ namespace HetsData.Repositories
                     .ThenInclude(c => c.ProjectStatusType)
                 .Include(x => x.HetRentalRequestAttachments)
                 .Include(x => x.DistrictEquipmentType)
+                    .ThenInclude(c => c.EquipmentType)
                 .FirstOrDefault(a => a.RentalRequestId == id);
 
             request.Status = request.RentalRequestStatusType.RentalRequestStatusTypeCode;

--- a/client/src/js/components/FilePicker.jsx
+++ b/client/src/js/components/FilePicker.jsx
@@ -25,7 +25,7 @@ class FilePicker extends React.Component {
     return (
       <span id={this.props.id} className={classNames.join(' ')}>
         <label>
-          <span className="btn btn-default" title="Pick files to upload">
+          <span className="btn btn-custom" title="Pick files to upload">
             <FontAwesomeIcon icon="folder-open" />
             {this.props.label ? ` ${this.props.label}` : null}
           </span>


### PR DESCRIPTION
Addressed isDumpTruck null reference error crash when going through rentalRequest. 

Add document button has an outline and is more obvious now. 