### PR TITLE
HETS-1331 bug fix when adding roles to users, additional HETS error messages and formatting

### DIFF
--- a/Server/HetsApi/Controllers/CurrentUserController.cs
+++ b/Server/HetsApi/Controllers/CurrentUserController.cs
@@ -48,7 +48,7 @@ namespace HetsApi.Controllers
         [HttpGet]
         [Route("favourites/{favouriteType?}")]
         [RequiresPermission(HetPermission.Login)]
-        public virtual ActionResult<List<UserFavouriteDto>> UsersCurrentFavouritesFavouriteTypeGet([FromRoute]string favouriteType)
+        public virtual ActionResult<List<UserFavouriteDto>> UsersCurrentFavouritesFavouriteTypeGet([FromRoute] string favouriteType)
         {
             // get the current user id
             string userId = _context.SmUserId;
@@ -78,7 +78,7 @@ namespace HetsApi.Controllers
         [HttpPost]
         [Route("favourites/{id}/delete")]
         [RequiresPermission(HetPermission.Login)]
-        public virtual ActionResult<UserFavouriteDto> UsersCurrentFavouritesIdDeletePost([FromRoute]int id)
+        public virtual ActionResult<UserFavouriteDto> UsersCurrentFavouritesIdDeletePost([FromRoute] int id)
         {
             // get the current user id
             string userId = _context.SmUserId;
@@ -112,7 +112,7 @@ namespace HetsApi.Controllers
         [HttpPost]
         [Route("favourites")]
         [RequiresPermission(HetPermission.Login)]
-        public virtual ActionResult<UserFavouriteDto> UsersCurrentFavouritesPost([FromBody]UserFavouriteDto item)
+        public virtual ActionResult<UserFavouriteDto> UsersCurrentFavouritesPost([FromBody] UserFavouriteDto item)
         {
             return UpdateFavourite(item);
         }
@@ -125,7 +125,7 @@ namespace HetsApi.Controllers
         [HttpPut]
         [Route("favourites")]
         [RequiresPermission(HetPermission.Login)]
-        public virtual ActionResult<UserFavouriteDto> UsersCurrentFavouritesPut([FromBody]UserFavouriteDto item)
+        public virtual ActionResult<UserFavouriteDto> UsersCurrentFavouritesPut([FromBody] UserFavouriteDto item)
         {
             return UpdateFavourite(item);
         }
@@ -308,7 +308,8 @@ namespace HetsApi.Controllers
             else if (_env.IsStaging())
             {
                 logoffUrl = _configuration.GetSection("Constants:LogoffUrl-Test").Value;
-            }else if (_env.IsEnvironment("Training"))
+            }
+            else if (_env.IsEnvironment("Training"))
             {
                 logoffUrl = _configuration.GetSection("Constants:LogoffUrl-Training").Value;
             }
@@ -317,7 +318,7 @@ namespace HetsApi.Controllers
                 logoffUrl = _configuration.GetSection("Constants:LogoffUrl-UAT").Value;
             }
 
-            LogoffModel response = new LogoffModel {LogoffUrl = logoffUrl};
+            LogoffModel response = new LogoffModel { LogoffUrl = logoffUrl };
 
             return new ObjectResult(new HetsResponse(response));
         }

--- a/Server/HetsApi/appsettings.json
+++ b/Server/HetsApi/appsettings.json
@@ -18,7 +18,7 @@
     "Maximum-Blank-Agreements": "3",
     "ExceptionDescriptions": {
       "HETS-01": "Record not found",
-      "HETS-02": "Record has been modified by anther user",
+      "HETS-02": "Record has been modified by another user",
       "HETS-03": "Invalid Region",
       "HETS-04": "Not data provided. Cannot create record",
       "HETS-05": "Error generating rental agreement pdf document",
@@ -59,7 +59,9 @@
       "HETS-40": "This owner has equipment that is part of an In Progress Rental Request. Release the list (finish hiring / delete) before making this change",
       "HETS-41": "This equipment is part of an In Progress Rental Request. Release the list (finish hiring / delete) before making this change",
       "HETS-42": "There is currently no equipment available to hire from this list",
-      "HETS-43": "Authorization failed"
+      "HETS-43": "Authorization failed",
+      "HETS-44": "Role record does not belong to user or one of the role records do not exist",
+      "HETS-45": "An active role already exists, cannot add a duplicate role"
     }
   },
   "SeniorityScoringRules": {

--- a/Server/HetsData/Repositories/UserRepository.cs
+++ b/Server/HetsData/Repositories/UserRepository.cs
@@ -14,7 +14,7 @@ namespace HetsData.Repositories
     public interface IUserRepository
     {
         List<UserDto> GetRecords();
-        UserDto GetRecord(int id);
+        UserDto GetRecord(int id, bool excludeInactiveRoles = false);
     }
     public class UserRepository : IUserRepository
     {
@@ -59,7 +59,7 @@ namespace HetsData.Repositories
         /// <param name="id"></param>
         /// <param name="context"></param>
         /// <returns></returns>
-        public UserDto GetRecord(int id)
+        public UserDto GetRecord(int id, bool excludeInactiveRoles = false)
         {
             HetUser user = _dbContext.HetUsers.AsNoTracking()
                 .Include(x => x.District)
@@ -70,7 +70,7 @@ namespace HetsData.Repositories
                             .ThenInclude(z => z.Permission)
                 .FirstOrDefault(x => x.UserId == id);
 
-            if (user != null)
+            if (user != null && excludeInactiveRoles)
             {
                 // remove inactive roles
                 user.HetUserRoles = user.HetUserRoles

--- a/client/src/js/views/UsersDetail.jsx
+++ b/client/src/js/views/UsersDetail.jsx
@@ -39,7 +39,7 @@ import SubHeader from '../components/ui/SubHeader.jsx';
 import Authorize from '../components/Authorize.jsx';
 
 import { daysFromToday, formatDateTime, today, isValidDate, toZuluTime } from '../utils/date';
-import { isBlank, notBlank } from '../utils/string';
+import { isBlank } from '../utils/string';
 import { sort, caseInsensitiveSort } from '../utils/array.js';
 
 class UsersDetail extends React.Component {
@@ -152,8 +152,7 @@ class UsersDetail extends React.Component {
     // been expired.
     var userRoles = this.props.user.userRoles.map((ur) => {
       return {
-        roleId: ur.roleId,
-        effectiveDate: ur.effectiveDate,
+        ...ur,
         expiryDate: userRole.id === ur.id ? userRole.expiryDate : ur.expiryDate,
       };
     });
@@ -383,7 +382,7 @@ class UsersDetail extends React.Component {
                     id="showExpiredOnly"
                     checked={this.state.ui.showExpiredOnly}
                     updateState={this.updateUIState}
-                    label="Show Expired Only"
+                    label="Include Expired Roles"
                   />{' '}
                 </SubHeader>
                 {(() => {
@@ -405,10 +404,12 @@ class UsersDetail extends React.Component {
                   );
 
                   var userRoles = _.filter(user.userRoles, (userRole) => {
-                    var include = notBlank(userRole.roleName);
-                    if (this.state.ui.showExpiredOnly) {
-                      include = include && userRole.expiryDate && daysFromToday(userRole.expiryDate) < 0;
+                    let include = true;
+
+                    if (!this.state.ui.showExpiredOnly) {
+                      include = daysFromToday(userRole.expiryDate) >= 0 || userRole.expiryDate === null;
                     }
+
                     return include;
                   });
 


### PR DESCRIPTION
Now checks that an active role doesn't already exist and uses UserRoleId to edit roles. 

Previously roles were checked using the RoleId which can exist in multiple records. Meaning editing roles would have unexpected effects. 

Also includes formatting from visual studio