### PR TITLE
1.11 rework of adding user districts. Cleaned up backend/frontend code. 

### DIFF
--- a/client/src/js/views/dialogs/DistrictEditDialog.jsx
+++ b/client/src/js/views/dialogs/DistrictEditDialog.jsx
@@ -79,8 +79,8 @@ class DistrictEditDialog extends React.Component {
 
         const district = {
           id: this.props.district.id,
-          user: { id: this.props.user.id },
-          district: { id: this.state.districtId },
+          userId: this.props.user.id,
+          districtId: this.state.districtId,
           isPrimary: this.state.isPrimary,
         };
 


### PR DESCRIPTION
placed the majority of verification logic at the beginning of the POST userDistricts. 

Changed the userDistrict object sent by the front end to only include the userId and districtId, rather than a user {} Object and district {} Object. 