### PR TITLE
Bugfix/hets document generation

### DIFF
--- a/Server/HetsApi.sln
+++ b/Server/HetsApi.sln
@@ -10,6 +10,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HetsApi", "HetsApi\HetsApi.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HetsReport", "HetsReport\HetsReport.csproj", "{7DFA1859-E5B0-4460-A5A5-5E5288A4AC94}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HetsCommon.Tests", "HetsCommon.Tests\HetsCommon.Tests.csproj", "{4B58551E-2DAE-4BC0-90D9-093CA63D7955}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{7DFA1859-E5B0-4460-A5A5-5E5288A4AC94}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DFA1859-E5B0-4460-A5A5-5E5288A4AC94}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DFA1859-E5B0-4460-A5A5-5E5288A4AC94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B58551E-2DAE-4BC0-90D9-093CA63D7955}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B58551E-2DAE-4BC0-90D9-093CA63D7955}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B58551E-2DAE-4BC0-90D9-093CA63D7955}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B58551E-2DAE-4BC0-90D9-093CA63D7955}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Server/HetsCommon.Tests/DateUtilsTests.cs
+++ b/Server/HetsCommon.Tests/DateUtilsTests.cs
@@ -1,0 +1,26 @@
+using HetsCommon;
+using Xunit;
+
+namespace HetsCommon.Tests;
+
+public class DateUtilsTests
+{
+    [Theory]
+    [InlineData(DateTimeKind.Utc)]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    public void FormatDateOnlyPreservesCalendarDate(DateTimeKind kind)
+    {
+        var selectedStartDate = new DateTime(2026, 4, 2, 0, 0, 0, kind);
+
+        var result = DateUtils.FormatDateOnly(selectedStartDate);
+
+        Assert.Equal("2026-APR-02", result);
+    }
+
+    [Fact]
+    public void FormatDateOnlyReturnsEmptyStringForNull()
+    {
+        Assert.Equal("", DateUtils.FormatDateOnly(null));
+    }
+}

--- a/Server/HetsCommon.Tests/HetsCommon.Tests.csproj
+++ b/Server/HetsCommon.Tests/HetsCommon.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HetsCommon\HetsCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Server/HetsCommon.Tests/MinistryNameHelperTests.cs
+++ b/Server/HetsCommon.Tests/MinistryNameHelperTests.cs
@@ -1,0 +1,37 @@
+using HetsCommon;
+using Xunit;
+
+namespace HetsCommon.Tests;
+
+public class MinistryNameHelperTests
+{
+    [Theory]
+    [InlineData("Ministry of Transportation and Infrastructure|South Peace")]
+    [InlineData("Ministry of Transportation  and Infrastructure|North Peace")]
+    [InlineData("Ministry of Transportation amp; Infrastructure|West Kootenay")]
+    [InlineData("Ministry of Transportation &amp; Infrastructure|West Kootenay")]
+    [InlineData("Ministry of Transportation & Infrastructure|West Kootenay")]
+    public void UseCurrentNameReplacesFormerNameVariants(string address)
+    {
+        var result = MinistryNameHelper.UseCurrentName(address);
+
+        Assert.StartsWith("Ministry of Transportation and Transit|", result);
+        Assert.DoesNotContain("Infrastructure", result);
+    }
+
+    [Fact]
+    public void UseCurrentNameLeavesCurrentNameUnchanged()
+    {
+        const string address = "Ministry of Transportation and Transit|North Peace";
+
+        Assert.Equal(address, MinistryNameHelper.UseCurrentName(address));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void UseCurrentNameReturnsEmptyStringForMissingValue(string? address)
+    {
+        Assert.Equal("", MinistryNameHelper.UseCurrentName(address));
+    }
+}

--- a/Server/HetsCommon/DateUtils.cs
+++ b/Server/HetsCommon/DateUtils.cs
@@ -47,6 +47,14 @@ namespace HetsCommon
         }
 
         /// <summary>
+        /// Formats a business date without applying a time zone conversion.
+        /// </summary>
+        public static string FormatDateOnly(DateTime? date)
+        {
+            return date?.ToString("yyyy-MMM-dd", CultureInfo.InvariantCulture).ToUpperInvariant() ?? "";
+        }
+
+        /// <summary>
         /// Returns Pacific time if VancouverTimeZone or PacificTimeZone is defined in the system
         /// Otherwise return UTC time.
         /// </summary>

--- a/Server/HetsCommon/MinistryNameHelper.cs
+++ b/Server/HetsCommon/MinistryNameHelper.cs
@@ -1,0 +1,22 @@
+using System.Text.RegularExpressions;
+
+#nullable enable
+
+namespace HetsCommon
+{
+    public static class MinistryNameHelper
+    {
+        public const string CurrentName = "Ministry of Transportation and Transit";
+
+        private static readonly Regex FormerNamePattern = new(
+            @"Ministry of Transportation\s+(?:and|&?amp;|&)\s+Infrastructure",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        public static string UseCurrentName(string? value)
+        {
+            return string.IsNullOrEmpty(value)
+                ? value ?? ""
+                : FormerNamePattern.Replace(value, CurrentName);
+        }
+    }
+}

--- a/Server/HetsData/Repositories/OwnerRepository.cs
+++ b/Server/HetsData/Repositories/OwnerRepository.cs
@@ -201,7 +201,7 @@ namespace HetsData.Repositories
                     // get address and contact info
                     string address = ownerList[0].LocalArea.ServiceArea.Address;
 
-                    address = address.Replace("Ministry of Transportation and Infrastructure", "Ministry of Transportation and Transit");
+                    address = MinistryNameHelper.UseCurrentName(address);
 
                     if (!string.IsNullOrEmpty(address))
                     {

--- a/Server/HetsData/Repositories/RentalAgreementRepository.cs
+++ b/Server/HetsData/Repositories/RentalAgreementRepository.cs
@@ -188,7 +188,7 @@ namespace HetsData.Repositories
             docModel.Equipment = agreement.Equipment;
             docModel.EquipmentRate = agreement.EquipmentRate;
             docModel.EstimateHours = agreement.EstimateHours;
-            docModel.EstimateStartWork = ConvertDate(agreement.EstimateStartWork);
+            docModel.EstimateStartWork = DateUtils.FormatDateOnly(agreement.EstimateStartWork);
             docModel.Number = agreement.Number;
             docModel.Project = agreement.Project;
             docModel.RateComment = agreement.RateComment;
@@ -268,45 +268,6 @@ namespace HetsData.Repositories
                 tempAddress = $"{tempAddress}  {agreement.Equipment.Owner.PostalCode}";
 
             return tempAddress;
-        }
-
-        private static string ConvertDate(DateTime? dateObject)
-        {
-            string result = "";
-
-            if (dateObject is DateTime dateObj)
-            {
-                // since the PDF template is raw HTML and won't convert a date object, we must adjust the time zone here
-                TimeZoneInfo tzi;
-
-                try
-                {
-                    // try the iana time zone first.
-                    tzi = TimeZoneInfo.FindSystemTimeZoneById("America / Vancouver");
-                }
-                catch
-                {
-                    tzi = null;
-                }
-
-                if (tzi == null)
-                {
-                    try
-                    {
-                        tzi = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-                    }
-                    catch
-                    {
-                        tzi = null;
-                    }
-                }
-
-                DateTime dt = tzi != null ? TimeZoneInfo.ConvertTime(dateObj, tzi) : dateObj;
-
-                result = dt.ToString("yyyy-MMM-dd").ToUpper();
-            }
-
-            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes two document-generation defects:

- **HETS-1364:** Rental agreements could print the estimated commencement date as the previous day.
- **HETS-1362:** Owner equipment re-registration forms could show the former Ministry of Transportation and Infrastructure name for some local areas, including Fort St. John.

## Root causes

### Rental agreement date

The selected start date was stored correctly at midnight, but report generation treated this date-only business value as a timestamp and converted it to Pacific time. Midnight UTC therefore became the previous calendar day.

### Ministry name

The owner verification header is populated from `HET_SERVICE_AREA.ADDRESS`. Legacy Production values use inconsistent forms of the former ministry name, including duplicate spaces and encoded ampersands. The previous exact string replacement only handled the single-space form.

## Changes

- Format rental agreement commencement dates without applying a timezone conversion.
- Add a shared date-only formatter that preserves the selected calendar date.
- Normalize legacy ministry-name variants to **Ministry of Transportation and Transit** when generating owner verification documents.
- Add a backend test project and regression coverage for:
  - UTC, local, and unspecified date kinds
  - null dates
  - one-space and duplicate-space ministry names
  - `amp;`, `&amp;`, and `&` ministry-name variants
  - already-current ministry names

## Validation

- Confirmed in OpenShift TEST that the rental request and resulting rental agreement both retain the selected `2026-04-15` date in the database.
- Confirmed in Production that Fort St. John maps to the North Peace service-area value containing duplicate spaces.
- Confirmed that the report templates already use Ministry of Transportation and Transit.
- All 12 backend regression tests pass.
- The full backend solution builds successfully.

## Database impact

No database migration is required. Existing legacy service-area values are normalized during document generation, while already-current values remain unchanged.